### PR TITLE
Allow multiple vernacular names in metadata, remove from observations.csv

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -47,10 +47,27 @@
           "type": "string",
           "format": "default"
         },
-        "vernacular_name": {
-          "description": "Common name of the species, preferably in English.",
-          "type": "string",
-          "format": "default"
+        "vernacular_names": {
+          "description": "Common or vernacular names of the species.",
+          "type": "object",
+          "format": "default",
+          "required": [
+            "name",
+            "language"
+          ],
+          "properties": {
+            "name": {
+              "description": "Common or vernacular name of the species.",
+              "type": "string",
+              "format": "default"
+            },
+            "language": {
+              "description": "Language of the vernacular name, as an ISO 639-1 code (e.g. `en` for English).",
+              "type": "string",
+              "format": "default",
+              "pattern": "^[a-z]{2}$"
+            }
+          }
         }
       }
     }

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -49,23 +49,26 @@
         },
         "vernacular_names": {
           "description": "Common or vernacular names of the species.",
-          "type": "object",
+          "type": "array",
           "format": "default",
-          "required": [
-            "name",
-            "language"
-          ],
-          "properties": {
-            "name": {
-              "description": "Common or vernacular name of the species.",
-              "type": "string",
-              "format": "default"
-            },
-            "language": {
-              "description": "Language of the vernacular name, as an ISO 639-1 code (e.g. `en` for English).",
-              "type": "string",
-              "format": "default",
-              "pattern": "^[a-z]{2}$"
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "language"
+            ],
+            "properties": {
+              "name": {
+                "description": "Common or vernacular name of the species.",
+                "type": "string",
+                "format": "default"
+              },
+              "language": {
+                "description": "Language of the vernacular name, as an ISO 639-1 code (e.g. `en` for English).",
+                "type": "string",
+                "format": "default",
+                "pattern": "^[a-z]{2}$"
+              }
             }
           }
         }

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -29,7 +29,7 @@
         }
       }
     },
-    "species": {
+    "taxa": {
       "description": "",
       "type": "object",
       "required": [
@@ -38,17 +38,17 @@
       ],
       "properties": {
         "taxon_id": {
-          "description": "Taxon ID of the species according to a taxonomic reference list defined by `taxon_id_reference`.",
+          "description": "Unique identifier of the taxon according to the taxonomic reference list defined by `taxon_id_reference`.",
           "type": "string",
           "format": "default"
         },
         "scientific_name": {
-          "description": "Scientific name of the species.",
+          "description": "Scientific name of the taxon.",
           "type": "string",
           "format": "default"
         },
         "vernacular_names": {
-          "description": "Common or vernacular names of the species.",
+          "description": "Common or vernacular names of the taxon.",
           "type": "array",
           "format": "default",
           "items": {
@@ -59,7 +59,7 @@
             ],
             "properties": {
               "name": {
-                "description": "Common or vernacular name of the species.",
+                "description": "Common or vernacular name of the taxon.",
                 "type": "string",
                 "format": "default"
               },
@@ -271,7 +271,7 @@
           "description": "Taxonomic coverage for this data package. It is based on a set of unique values from `scientific_name` field in `observations.csv` table.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/species"
+            "$ref": "#/definitions/taxa"
           }
         },
         "taxon_id_reference": {

--- a/observations-table-schema.json
+++ b/observations-table-schema.json
@@ -1,6 +1,6 @@
 {
   "title": "Observations",
-  "description": "Table with observations based on the multimedia files. Associated with deployments (`deployment_id`), sequences (`sequence_id`) and optionally individual multimedia files (`multimedia_id`). Observations can mark non-animal events (camera setup, human, empty) or one or more animal observations (`observation_type` = `animal`) of a certain species, count, age, sex, behaviour and/or individual.",
+  "description": "Table with observations based on the multimedia files. Associated with deployments (`deployment_id`), sequences (`sequence_id`) and optionally individual multimedia files (`multimedia_id`). Observations can mark non-animal events (camera setup, human, empty) or one or more animal observations (`observation_type` = `animal`) of a certain taxon, count, age, sex, behaviour and/or individual.",
   "fields": [
     {
       "name": "observation_id",
@@ -109,7 +109,7 @@
       "name": "taxon_id",
       "type": "string",
       "format": "default",
-      "description": "Taxon identifier for the `scientific_name` according to the taxonomic reference list defined by `taxon_id_reference` in the package metadata.",
+      "description": "Unique identifier of the `scientific_name` according to the taxonomic reference list defined by `taxon_id_reference` in the package metadata.",
       "example": "QLXL",
       "constraints": {
         "required": false

--- a/observations-table-schema.json
+++ b/observations-table-schema.json
@@ -106,11 +106,11 @@
       }
     },
     {
-      "name": "vernacular_name",
+      "name": "taxon_id",
       "type": "string",
       "format": "default",
-      "description": "Common name of the observed individual(s), preferably in English.",
-      "example": "wolf",
+      "description": "Taxon identifier for the `scientific_name` according to the taxonomic reference list defined by `taxon_id_reference` in the package metadata.",
+      "example": "QLXL",
       "constraints": {
         "required": false
       }


### PR DESCRIPTION
Fixes #115 and #108 and #120. Was tested on an example data package.

~I would like to have an answer to #120 before finishing this PR.~