### PR TITLE
Fix typo: url is called path

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -9,7 +9,7 @@
       "type": "object",
       "required": [
         "title",
-        "url"
+        "path"
       ],
       "properties": {
         "title": {


### PR DESCRIPTION
The specs require the property `url`, while it is actually called `path`