### PR TITLE
Use pattern for file path

### DIFF
--- a/multimedia-table-schema.json
+++ b/multimedia-table-schema.json
@@ -46,7 +46,7 @@
     {
       "name": "file_path",
       "type": "string",
-      "format": "uri",
+      "format": "default",
       "description": "Url or relative path to the multimedia file, respectively for externally hosted files or files that are part of this package. Additional information on how to access this file is provided in a package-level metadata.",
       "example": [
         "https://trapper.org/storage/resource/media/259024/file/",
@@ -54,7 +54,8 @@
         "DEP0001/IMG0001.jpg"
       ],
       "constraints": {
-        "required": true
+        "required": true,
+        "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$"
       }
     },
     {


### PR DESCRIPTION
Fixes #123. Uses same pattern for url-or-path as in https://specs.frictionlessdata.io/schemas/data-resource.json

Will stop absolute and relative parent paths:

```
===  =====  ================  ================================================================================================================================================================================
row  field  code              message
===  =====  ================  ================================================================================================================================================================================
  8      5  constraint-error  The cell "./file.jpg" in row at position "8" and field "file_path" at position "5" does not conform to a constraint: constraint "pattern" is "^(?=^[^./~])(^((?!\.{2}).)*$).*$"
  9      5  constraint-error  The cell "/file.jpg" in row at position "9" and field "file_path" at position "5" does not conform to a constraint: constraint "pattern" is "^(?=^[^./~])(^((?!\.{2}).)*$).*$"
 10      5  constraint-error  The cell "~/file.jpg" in row at position "10" and field "file_path" at position "5" does not conform to a constraint: constraint "pattern" is "^(?=^[^./~])(^((?!\.{2}).)*$).*$"
===  =====  ================  ================================================================================================================================================================================
```