### PR TITLE
Add rights_holder and bibliographic_citation

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -17,7 +17,7 @@
       ],
       "properties": {
         "multimedia_access": {
-          "description": "Information about the accessibilty of the multimedia files listed in `multimedia.csv`.",
+          "description": "Information about the accessibility of the multimedia files listed in `multimedia.csv`.",
           "type": "object",
           "required": [
             "remote",

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -74,6 +74,10 @@
           "description": "Person or organization owning or managing rights over this data package. Term borrowed from [Dublin Core](http://purl.org/dc/terms/rightsHolder).",
           "type": "string"
         },
+        "bibliographic_citation": {
+          "description": "Bibliographic/recommended citation for this data package. Term borrowed from [Dublin Core](http://purl.org/dc/terms/bibliographicCitation).",
+          "type": "string"
+        },
         "project": {
           "description": "Camera trap project that generated the data in this data package.",
           "type": "object",

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -70,6 +70,10 @@
             }
           }
         },
+        "rights_holder": {
+          "description": "Person or organization owning or managing rights over this data package. Term borrowed from [Dublin Core](http://purl.org/dc/terms/rightsHolder).",
+          "type": "string"
+        },
         "project": {
           "description": "Camera trap project that generated the data in this data package.",
           "type": "object",


### PR DESCRIPTION
Terms indicated as borrowed from Dublin Core (but with under_score writing for consistency). Part of suggested changes in #133.