### PR TITLE
Remove methods

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -162,10 +162,6 @@
               "description": "Maximum number of seconds between timestamps of successive multimedia files to be considered part of a single sequence and be assigned the same `sequence_id`.",
               "type": "integer"
             },
-            "methods": {
-              "description": "Description of the methodology used to collect and process data.",
-              "type": "string"
-            },
             "references": {
               "description": "List of references related to the project (e.g. references cited in the project description). References ideally include a DOI.",
               "type": "array",


### PR DESCRIPTION
This is a free text field that is likely difficult to separate from project description, so it is removed and users can describe it there. Extensive methodology is better discussed in a (data) paper. Part of suggested changes in #133.