### PR TITLE
Remove project-level bait use

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -133,23 +133,6 @@
               "uniqueItems": true,
               "minItems": 1
             },
-            "bait_use": {
-              "type": "array",
-              "description": "Type of bait (if any) that was used with cameras.",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "none",
-                  "scent",
-                  "food",
-                  "visual",
-                  "acoustic",
-                  "other"
-                ]
-              },
-              "uniqueItems": true,
-              "minItems": 1
-            },
             "classification_level": {
               "type": "string",
               "description": "Information about a focal level of the classification process. `sequence`: classifications (i.e. rows in `observations.csv` table) are provided at a sequence level (multiple multimedia files can be part of one sequence); `multimedia`: classifications are available for each single multimedia file.",


### PR DESCRIPTION
What bait was used is less important at project level and it can conflict with the information at deployment level. The term is therefore removed (but retained for deployments). Part of suggested changes in #133.