### PR TITLE
Require data packages to have a creation date

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -9,6 +9,7 @@
     },
     {
       "required": [
+        "created",
         "multimedia_access",
         "project",
         "spatial",


### PR DESCRIPTION
@kbubnicki this wasn't something we discussed, but @yliefting and I think it would be a good idea to require this property at package level.