### PR TITLE
Make profile a required property, it needs to be a URL

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -9,6 +9,7 @@
     },
     {
       "required": [
+        "profile",
         "multimedia_access",
         "project",
         "spatial",
@@ -16,6 +17,9 @@
         "taxonomic"
       ],
       "properties": {
+        "profile": {
+          "format": "uri"
+        },
         "multimedia_access": {
           "description": "Information about the accessibilty of the multimedia files listed in `multimedia.csv`.",
           "type": "object",


### PR DESCRIPTION
One can only validate a Camtrap DP package properly, if it links to e.g.:

```
"profile": "https://raw.githubusercontent.com/tdwg/camtrap-dp/0.1.3/camtrap-dp-profile.json"
```

So it makes sense to make `profile` required. I think it also makes sense to require this to be a URI, but I don't think we can specify more, except maybe that it should contain `camtrap-dp`?

Note that not having a `profile` won't fail the validation, because `frictionless validate datapackage.json` will then assume it is a regular Data Package. Still, I think it is good to indicate to the user that we expect the `profile` property to be there.