### PR TITLE
Require exactly 3 resources with names "deployments", "multimedia", "observations"

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -23,6 +23,21 @@
         "profile": {
           "format": "uri"
         },
+        "resources": {
+          "minItems": 3,
+          "maxItems": 3,
+          "items": {
+            "properties": {
+              "name": {
+                "enum": [
+                  "deployments",
+                  "multimedia",
+                  "observations"
+                ]
+              }
+            }
+          }
+        },
         "multimedia_access": {
           "description": "Information about the accessibility of the multimedia files listed in `multimedia.csv`.",
           "type": "object",


### PR DESCRIPTION
Fix #145

Note that `resources` is already a required property in data package, so not repeated here.

Note that I did not add `uniqueItems` because validation will add numbers to resources if they have the same name (thus making them unique, and failing the enum).