### PR TITLE
Express vernacular names as language_code: name pairs

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -221,26 +221,15 @@
                 "type": "string"
               },
               "vernacular_names": {
-                "description": "Common or vernacular names of the taxon.",
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "name",
-                    "language"
-                  ],
-                  "properties": {
-                    "name": {
-                      "description": "Common or vernacular name of the taxon.",
-                      "type": "string"
-                    },
-                    "language": {
-                      "description": "Language of the vernacular name, as an ISO 639-1 code (e.g. `en` for English).",
-                      "type": "string",
-                      "pattern": "^[a-z]{2}$"
-                    }
+                "description": "Common or vernacular names of the taxon, as `language_code: name` pairs. Language code should follow ISO 639-1 (e.g. `en` for English).",
+                "type": "object",
+                "patternProperties": {
+                  "^[a-z]{2}$": {
+                    "description": "Common or vernacular name of the taxon in that language.",
+                    "type": "string"
                   }
-                }
+                },
+                "additionalProperties": false
               }
             }
           }

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -93,7 +93,6 @@
             "sampling_design",
             "sensor_method",
             "animal_types",
-            "bait_use",
             "classification_level",
             "sequence_interval"
           ],


### PR DESCRIPTION
Fix #147. Will validate that the keys in `vernacular_names` consist of 2 letters and have a string value (e.g. "en": "wolf").