### PR TITLE
Remove multimedia access

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -12,7 +12,6 @@
         "profile",
         "created",
         "contributors",
-        "multimedia_access",
         "project",
         "spatial",
         "temporal",
@@ -22,33 +21,6 @@
       "properties": {
         "profile": {
           "format": "uri"
-        },
-        "multimedia_access": {
-          "description": "Information about the accessibility of the multimedia files listed in `multimedia.csv`.",
-          "type": "object",
-          "required": [
-            "remote",
-            "public"
-          ],
-          "properties": {
-            "remote": {
-              "description": "`true` if multimedia files are stored remotely (e.g. in the cloud) and `false` if these are part of the data package. In the latter case, relative paths in `multimedia.csv` start from the root of the data package.",
-              "type": "boolean"
-            },
-            "public": {
-              "description": "`true` if URLs to multimedia files in `multimedia.csv` are publicly accessible. Additional information about the required authentication process should be provided in the `auth_type` field if `false`.",
-              "type": "boolean"
-            },
-            "auth_type": {
-              "description": "Type of authentication required to get access to multimedia files.",
-              "type": "string",
-              "enum": [
-                "basic",
-                "token",
-                "ldap"
-              ]
-            }
-          }
         },
         "organizations": {
           "description": "List of organizations related to this data package.",

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Camera Trap Data Package Profile",
-  "description": "This is the profile of standardized camera trap data package.",
+  "title": "Camera Trap Data Package",
+  "description": "Data exchange format for camera trap data. https://tdwg.github.io/camtrap-dp/",
   "type": "object",
   "allOf": [
     {

--- a/multimedia-table-schema.json
+++ b/multimedia-table-schema.json
@@ -27,7 +27,7 @@
       "name": "sequence_id",
       "type": "string",
       "format": "default",
-      "description": "Unique identifier (within a project) of the sequence this multimedia file belongs to. Sequences contain one or more multimedia files (e.g. a single image or video or a sequence of successive images or videos) and are defined by `sequence_interval` in the package metadata.",
+      "description": "Unique identifier (within a project) of the sequence this multimedia file belongs to. Sequences contain one or more multimedia files (e.g. a single image or video or a sequence of successive images or videos) and are defined by `sequence_interval` in the data package metadata.",
       "example": "seq1",
       "constraints": {
         "required": true
@@ -47,7 +47,7 @@
       "name": "file_path",
       "type": "string",
       "format": "default",
-      "description": "Url or relative path to the multimedia file, respectively for externally hosted files or files that are part of this package. Additional information on how to access this file is provided in a package-level metadata.",
+      "description": "Url or relative path to the multimedia file, respectively for externally hosted files or files that are part of this data package. Additional information on how to access this file is provided in a package-level metadata.",
       "example": [
         "https://trapper.org/storage/resource/media/259024/file/",
         "gs://wildlife_insights/Project/Images/CT-011/IMG0001.jpg",

--- a/multimedia-table-schema.json
+++ b/multimedia-table-schema.json
@@ -47,7 +47,7 @@
       "name": "file_path",
       "type": "string",
       "format": "default",
-      "description": "Url or relative path to the multimedia file, respectively for externally hosted files or files that are part of this data package. Additional information on how to access this file is provided in a package-level metadata.",
+      "description": "Url or relative path to the multimedia file, respectively for externally hosted files or files that are part of this data package.",
       "example": [
         "https://trapper.org/storage/resource/media/259024/file/",
         "gs://wildlife_insights/Project/Images/CT-011/IMG0001.jpg",

--- a/observations-table-schema.json
+++ b/observations-table-schema.json
@@ -109,7 +109,7 @@
       "name": "taxon_id",
       "type": "string",
       "format": "default",
-      "description": "Unique identifier of the `scientific_name` according to the taxonomic reference list defined by `taxon_id_reference` in the package metadata.",
+      "description": "Unique identifier of the `scientific_name` according to the taxonomic reference list defined by `taxon_id_reference` in the data package metadata.",
       "example": "QLXL",
       "constraints": {
         "required": false


### PR DESCRIPTION
PR to simplifying multimedia_access properties. Still in draft, since it hasn't been decided yet if the `public` property should be kept or not (`remote` and `auth` will disappear). See #124