### PR TITLE
Use "unknown" rather than "undefined" (sex, age, observation_type) and "blank" rather than "empty"

### DIFF
--- a/observations-table-schema.json
+++ b/observations-table-schema.json
@@ -57,7 +57,7 @@
       "name": "observation_type",
       "type": "string",
       "format": "default",
-      "description": "Type of observation. All categories in this vocabulary have to be understandable from an AI point of view. `undefined` describes classifications with a confidence level below some predefined threshold i.e. neither humans nor AI can say what was recorded.",
+      "description": "Type of observation. All categories in this vocabulary have to be understandable from an AI point of view. `unknown` describes classifications with a confidence level below some predefined threshold i.e. neither humans nor AI can say what was recorded.",
       "example": "animal",
       "constraints": {
         "required": true,
@@ -65,8 +65,8 @@
           "animal",
           "human",
           "vehicle",
-          "undefined",
           "blank",
+          "unknown",
           "unclassified"
         ]
       }
@@ -150,7 +150,7 @@
           "subadult",
           "juvenile",
           "offspring",
-          "undefined"
+          "unknown"
         ]
       }
     },
@@ -165,7 +165,7 @@
         "enum": [
           "female",
           "male",
-          "undefined"
+          "unknown"
         ]
       }
     },

--- a/observations-table-schema.json
+++ b/observations-table-schema.json
@@ -1,6 +1,6 @@
 {
   "title": "Observations",
-  "description": "Table with observations based on the multimedia files. Associated with deployments (`deployment_id`), sequences (`sequence_id`) and optionally individual multimedia files (`multimedia_id`). Observations can mark non-animal events (camera setup, human, empty) or one or more animal observations (`observation_type` = `animal`) of a certain taxon, count, age, sex, behaviour and/or individual.",
+  "description": "Table with observations based on the multimedia files. Associated with deployments (`deployment_id`), sequences (`sequence_id`) and optionally individual multimedia files (`multimedia_id`). Observations can mark non-animal events (camera setup, human, blank) or one or more animal observations (`observation_type` = `animal`) of a certain taxon, count, age, sex, behaviour and/or individual.",
   "fields": [
     {
       "name": "observation_id",
@@ -65,8 +65,8 @@
           "animal",
           "human",
           "vehicle",
-          "empty",
           "undefined",
+          "blank",
           "unclassified"
         ]
       }


### PR DESCRIPTION
Changes `observation_type = empty` to `observation_type = blank`.

Changes `observation_type = undefined` to `observation_type = unknown`:
- The term `undefined` has lead to some confusion with users, especially in combination with `unclassified`.
- `unknown` is more widely understood and used, e.g. at [Movebank](http://vocab.nerc.ac.uk/collection/MVB/current/MVB000023/). It was also suggested from the start: https://github.com/tdwg/camtrap-dp/issues/12#issuecomment-796741265
- For consistency, the value has also been renamed for sex and age.