### PR TITLE
Add and describe coordinate_uncertainty_in_meters

### DIFF
--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -61,7 +61,7 @@
       "name": "coordinate_uncertainty",
       "type": "integer",
       "format": "default",
-      "description": "Horizontal distance in meters from the given `latitude` and `longitude` describing the smallest circle containing the location of the camera trap. Use for example when coordinates were [rounded](https://en.wikipedia.org/wiki/Decimal_degrees#Precision) to conceal the precise location of an active camera. Term borrowed from [Darwin Core](http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters).",
+      "description": "Horizontal distance in meters from the given `latitude` and `longitude` describing the smallest circle containing the location of the camera trap. Use for example when coordinates are [rounded](https://en.wikipedia.org/wiki/Decimal_degrees#Precision) to conceal the precise location of an active camera. Term borrowed from [Darwin Core](http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters).",
       "example": "111",
       "constraints": {
         "required": false,

--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -62,7 +62,7 @@
       "type": "integer",
       "format": "default",
       "description": "Horizontal distance in meters from the given `latitude` and `longitude` describing the smallest circle containing the location of the camera trap. Use for example when coordinates are [rounded](https://en.wikipedia.org/wiki/Decimal_degrees#Precision) to conceal the precise location of an active camera. Term borrowed from [Darwin Core](http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters).",
-      "example": "111",
+      "example": "100",
       "constraints": {
         "required": false,
         "minimum": 1

--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -58,10 +58,10 @@
       }
     },
     {
-      "name": "coordinate_uncertainty_in_meters",
+      "name": "coordinate_uncertainty",
       "type": "integer",
       "format": "default",
-      "description": "Horizontal distance in meters from the given `latitude` and `longitude` describing the smallest circle containing the location of the camera trap. E.g. [111 meters](https://en.wikipedia.org/wiki/Decimal_degrees#Precision) for coordinates that were rounded to 3 decimals to conceal the precise location of an active camera. Term borrowed from [Darwin Core](http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters).",
+      "description": "Horizontal distance in meters from the given `latitude` and `longitude` describing the smallest circle containing the location of the camera trap. Use for example when coordinates were [rounded](https://en.wikipedia.org/wiki/Decimal_degrees#Precision) to conceal the precise location of an active camera. Term borrowed from [Darwin Core](http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters).",
       "example": "111",
       "constraints": {
         "required": false,

--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -58,6 +58,17 @@
       }
     },
     {
+      "name": "coordinate_uncertainty_in_meters",
+      "type": "integer",
+      "format": "default",
+      "description": "Horizontal distance in meters from the given `latitude` and `longitude` describing the smallest circle containing the location of the camera trap. E.g. [111 meters](https://en.wikipedia.org/wiki/Decimal_degrees#Precision) for coordinates that were rounded to 3 decimals to conceal the precise location of an active camera. Term borrowed from [Darwin Core](http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters).",
+      "example": "111",
+      "constraints": {
+        "required": false,
+        "minimum": 1
+      }
+    },
+    {
       "name": "start",
       "type": "datetime",
       "format": "%Y-%m-%dT%H:%M:%S%z",

--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -105,7 +105,7 @@
       "name": "camera_id",
       "type": "string",
       "format": "default",
-      "description": "Unique identifier (within a project) of the camera used for this deployment. This can be e.g. the camera device serial number.",
+      "description": "Unique identifier (within a project) of the camera used for this deployment (e.g. the camera device serial number).",
       "example": "P800HG08192031",
       "constraints": {
         "required": false


### PR DESCRIPTION
Term is not required.

@tucotuco am I using wrong terms in this definition:

> Horizontal distance in meters from the given `latitude` and `longitude` describing the smallest circle containing the location of the camera trap. E.g. [111 meters](https://en.wikipedia.org/wiki/Decimal_degrees#Precision) for coordinates that were rounded to 3 decimals to conceal the precise location of an active camera. Term borrowed from [Darwin Core](http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters). 