### PR TITLE
Require schema names (and therefore schemas)

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -32,6 +32,20 @@
                   "multimedia",
                   "observations"
                 ]
+              },
+              "schema": {
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "enum": [
+                      "deployments",
+                      "multimedia",
+                      "observations"
+                    ]
+                  }
+                }
               }
             }
           }

--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -1,4 +1,5 @@
 {
+  "name": "deployments",
   "title": "Deployments",
   "description": "Table with camera trap deployments. Includes `deployment_id`, start, end, location and camera setup information.",
   "fields": [

--- a/multimedia-table-schema.json
+++ b/multimedia-table-schema.json
@@ -1,4 +1,5 @@
 {
+  "name": "multimedia",
   "title": "Multimedia",
   "description": "Table with multimedia files (images/videos) captured by the camera traps. Associated with deployments (`deployment_id`) and organized in sequences (`sequence_id`). Includes timestamp and file path.",
   "fields": [

--- a/observations-table-schema.json
+++ b/observations-table-schema.json
@@ -1,4 +1,5 @@
 {
+  "name": "observations",
   "title": "Observations",
   "description": "Table with observations based on the multimedia files. Associated with deployments (`deployment_id`), sequences (`sequence_id`) and optionally individual multimedia files (`multimedia_id`). Observations can mark non-animal events (camera setup, human, blank) or one or more animal observations (`observation_type` = `animal`) of a certain taxon, count, age, sex, behaviour and/or individual.",
   "fields": [


### PR DESCRIPTION
Relates to #172

Requires data resources to have a `schema` with a specific `name` (and therefore having a schema). That at least avoids Camtrap DP datasets without Table Schemas. Users could technically verbosely include their own schema (that will need one of the three names), but linking to the versioned one is easier. The setup generates readable error reports:

```
package-error The data package has an error: "'name' is a required property" at "resources/2/schema" in metadata and at "allOf/1/properties/resources/items/properties/schema/required" in profile
```

Notes:

I chose `name` rather than the already existing `title`, because title is intended for humans.

It didn't seem to work to make `schema` property itself required (those without one still passed validation), probably because there are some conflicting rules in the main `data-package.json` specs. 