### PR TITLE
Give more meaningful names to GitHub Actions jobs

### DIFF
--- a/.github/workflows/validate-example-current-schema.yml
+++ b/.github/workflows/validate-example-current-schema.yml
@@ -3,7 +3,7 @@ name: Validate example against current schemas
 on: push
 
 jobs:
-  build:
+  validate-example-current-schema:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/validate-example-versioned-schema.yml
+++ b/.github/workflows/validate-example-versioned-schema.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  validate-example-versioned-schema:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/validate-profile-and-schemas.yml
+++ b/.github/workflows/validate-profile-and-schemas.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  validate-profile-and-schemas:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Update jobs titles as follows (rather than it being called `build` after the slash for both):

<img width="683" alt="Screenshot 2021-12-16 at 12 59 30" src="https://user-images.githubusercontent.com/600993/146367822-c8f7d977-7e45-4634-ad4d-1e82c8758da9.png">
