### PR TITLE
Require *tabular* resources

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -25,12 +25,21 @@
           "minItems": 3,
           "maxItems": 3,
           "items": {
+            "required": [
+              "schema",
+              "profile"
+            ],
             "properties": {
               "name": {
                 "enum": [
                   "deployments",
                   "media",
                   "observations"
+                ]
+              },
+              "profile": {
+                "enum": [
+                  "tabular-data-resource"
                 ]
               },
               "schema": {

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -38,9 +38,7 @@
                 ]
               },
               "profile": {
-                "enum": [
-                  "tabular-data-resource"
-                ]
+                "const": "tabular-data-resource"
               },
               "schema": {
                 "required": [


### PR DESCRIPTION
We extend [Data Package](https://specs.frictionlessdata.io/schemas/data-package.json), which has little requirements for their resources (name + path/data).

We actually want the same requirements as [Tabular Data Package](https://specs.frictionlessdata.io/schemas/tabular-data-package.json) (but can't extend on that one), i.e. name + path/data + schema + profile. The first two are already borrowed from data-package, but we have to re-add schema + profile. Tabular data package also requires a specific value for profile, i.e. tabular-data-profile.

This PR implements that enforcement.