### PR TITLE
Require license to have scope property

### DIFF
--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -24,12 +24,12 @@ layout: base
 
       {{ p1.description | markdownify }}
 
-      {% if p1.['skos:exactMatch'] %}
-        <p class="small text-muted">Same as <a href="{{ p1.['skos:exactMatch'] }}">{{ p1.['skos:exactMatch'] }}</a></p>
-      {% elsif p1.['skos:narrowMatch'] %}
-        <p class="small text-muted">Narrower than <a href="{{ p1.['skos:narrowMatch'] }}">{{ p1.['skos:narrowMatch'] }}</a></p>
-      {% elsif p1.['skos:broadMatch'] %}
-        <p class="small text-muted">Broader than <a href="{{ p1.['skos:broadMatch'] }}">{{ p1.['skos:broadMatch'] }}</a></p>
+      {% if p1['skos:exactMatch'] %}
+        <p class="small text-muted">Same as <a href="{{ p1['skos:exactMatch'] }}">{{ p1['skos:exactMatch'] }}</a></p>
+      {% elsif p1['skos:narrowMatch'] %}
+        <p class="small text-muted">Narrower than <a href="{{ p1['skos:narrowMatch'] }}">{{ p1['skos:narrowMatch'] }}</a></p>
+      {% elsif p1['skos:broadMatch'] %}
+        <p class="small text-muted">Broader than <a href="{{ p1['skos:broadMatch'] }}">{{ p1['skos:broadMatch'] }}</a></p>
       {% endif %}
 
       {% if p1.properties %}
@@ -75,12 +75,12 @@ layout: base
                     {% endfor %}
                     </ul>
                   {% endif %}
-                  {% if p2.['skos:exactMatch'] %}
-                    <span class="small text-muted">Same as <a href="{{ p2.['skos:exactMatch'] }}">{{ p2.['skos:exactMatch'] }}</a></span>
-                  {% elsif p2.['skos:narrowMatch'] %}
-                    <span class="small text-muted">Narrower than <a href="{{ p2.['skos:narrowMatch'] }}">{{ p2.['skos:narrowMatch'] }}</a></span>
-                  {% elsif p2.['skos:broadMatch'] %}
-                    <span class="small text-muted">Broader than <a href="{{ p2.['skos:broadMatch'] }}">{{ p2.['skos:broadMatch'] }}</a></span>
+                  {% if p2['skos:exactMatch'] %}
+                    <span class="small text-muted">Same as <a href="{{ p2['skos:exactMatch'] }}">{{ p2['skos:exactMatch'] }}</a></span>
+                  {% elsif p2['skos:narrowMatch'] %}
+                    <span class="small text-muted">Narrower than <a href="{{ p2['skos:narrowMatch'] }}">{{ p2['skos:narrowMatch'] }}</a></span>
+                  {% elsif p2['skos:broadMatch'] %}
+                    <span class="small text-muted">Broader than <a href="{{ p2['skos:broadMatch'] }}">{{ p2['skos:broadMatch'] }}</a></span>
                   {% endif %}
                 </td>
                 <td>{{ p2.type }}</td>

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -19,6 +19,7 @@
       ],
       "properties": {
         "profile": {
+          "description": "URL of the used Camtrap DP Profile version (e.g. `https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/camtrap-dp-profile.json`).",
           "format": "uri"
         },
         "licenses": {
@@ -38,11 +39,13 @@
           }
         },
         "resources": {
+          "description": "An `array` of Tabular Data Resource objects, each compliant with the [Tabular Data Resource](https://specs.frictionlessdata.io/tabular-data-resource/) specification.",
           "minItems": 3,
           "maxItems": 3,
           "items": {
             "properties": {
               "name": {
+                "description": "Identifier for the resource. Only names are allowed: `deployments`, `media` and `observations` (see [Data](../data/)).",
                 "enum": [
                   "deployments",
                   "media",
@@ -50,6 +53,7 @@
                 ]
               },
               "schema": {
+                "description": "URL of the used Camtrap DP Table Schema version (e.g. `https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/deployments-table-schema.json`).",
                 "required": [
                   "name"
                 ],

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -23,6 +23,7 @@
           "format": "uri"
         },
         "licenses": {
+          "description": "[Licenses](https://specs.frictionlessdata.io/data-package/#licenses) under which the Data Package is published. If provided, requires at least a license for the content of the Data Package and one for the media files referenced in `media.csv` (see `scope`).",
           "minItems": 2,
           "items": {
             "required": [
@@ -30,6 +31,7 @@
             ],
             "properties": {
               "scope": {
+                "description": "Scope of the license. `data` for the license under which the content of the Data Package is provided, `media` for the license under which the media files referenced in `media.csv` are provided.",
                 "enum": [
                   "data",
                   "media"

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -22,6 +22,7 @@
           "format": "uri"
         },
         "licenses": {
+          "minItems": 2,
           "items": {
             "required": [
               "scope"

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -21,6 +21,21 @@
         "profile": {
           "format": "uri"
         },
+        "licenses": {
+          "items": {
+            "required": [
+              "scope"
+            ],
+            "properties": {
+              "scope": {
+                "enum": [
+                  "data",
+                  "media"
+                ] 
+              }
+            }
+          }
+        },
         "resources": {
           "minItems": 3,
           "maxItems": 3,

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Camera Trap Data Package",
   "description": "Data exchange format for camera trap data. https://tdwg.github.io/camtrap-dp/",
-  "version": "0.1.6",
   "type": "object",
   "allOf": [
     {

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Camera Trap Data Package",
   "description": "Data exchange format for camera trap data. https://tdwg.github.io/camtrap-dp/",
+  "version": "0.1.6",
   "type": "object",
   "allOf": [
     {
@@ -47,7 +48,7 @@
           "items": {
             "properties": {
               "name": {
-                "description": "Identifier for the resource. Only names are allowed: `deployments`, `media` and `observations` (see [Data](../data/)).",
+                "description": "Identifier for the resource. Allowed names are `deployments`, `media` and `observations` (see [Data](../data/)).",
                 "enum": [
                   "deployments",
                   "media",

--- a/example/datapackage.json
+++ b/example/datapackage.json
@@ -3,6 +3,16 @@
   "id": "https://doi.org/10.5281/zenodo.4893244",
   "profile": "https://raw.githubusercontent.com/tdwg/camtrap-dp/0.1.6/camtrap-dp-profile.json",
   "created": "2021-07-07T16:08:15Z",
+  "licenses": [
+    {
+      "name": "CC0-1.0",
+      "scope": "data"
+    },
+    {
+      "path": "http://creativecommons.org/licenses/by/4.0/",
+      "scope": "media"
+    }
+  ],
   "sources": [
     {
       "title": "Agouti",

--- a/pages/metadata.md
+++ b/pages/metadata.md
@@ -13,9 +13,9 @@ For a full example, see [this `datapackage.json`](https://raw.githubusercontent.
 
 - [`name`](https://specs.frictionlessdata.io/data-package/#name)
 - [`id`](https://specs.frictionlessdata.io/data-package/#id)
-- [`profile`](https://specs.frictionlessdata.io/data-package/#profile)*
+- [`profile`](#profile)*
 - [`created`](https://specs.frictionlessdata.io/data-package/#created)*
-- [`licenses`](https://specs.frictionlessdata.io/data-package/#licenses)
+- [`licenses`](#licenses)
 - [`sources`](https://specs.frictionlessdata.io/data-package/#sources)
 - [`contributors`](https://specs.frictionlessdata.io/data-package/#contributors)*
 - [`resources`](#resources)*: the data files, see [Data](../data/).


### PR DESCRIPTION
Implements https://github.com/tdwg/camtrap-dp/issues/189 by requiring a `scope = data` or `scope = media` property for licenses. Notes:

- `licenses` is not a required property (cf. Data Package and behaviour before), so it can be excluded. This is useful for e.g. exports from management systems where no license is specified.
- When added, at minimum **two** licenses are required, because we want people to always indicate one for data AND media. @ben-norton @kbubnicki **is that OK?** Note that one _could_ indicate even more licenses, e.g. if multiple licenses apply to the media files. It has the drawback that users don't know which one applies to which media files however, a drawback already discussed in #189.
- When added, the license needs a `scope` property, which should either be `data` or `media`. Note that I don't know how to enforce both to be different. @ben-norton @kbubnicki **is `data` a good name?** Alternatives I consider less good are `metadata` and `package`.

~Note to self: only merge PR after the example package has licenses (currently it has none, which also passes validation).~ **done**