### PR TITLE
Require resource schema URL to include version number

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -3,6 +3,11 @@
   "title": "Camera Trap Data Package",
   "description": "Data exchange format for camera trap data. https://tdwg.github.io/camtrap-dp/",
   "type": "object",
+  "$defs": {
+    "version": {
+      "pattern": "0\\.1\\.6"
+    }
+  },  
   "allOf": [
     {
       "$ref": "https://frictionlessdata.io/schemas/data-package.json"
@@ -56,6 +61,7 @@
               },
               "schema": {
                 "description": "URL of the used Camtrap DP Table Schema version (e.g. `https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/deployments-table-schema.json`).",
+                "$ref": "#$defs/version",
                 "required": [
                   "name"
                 ],


### PR DESCRIPTION
Data Packages have to point to Camtrap DP in 4 places: the profile and 3 resource schemas. This cannot be avoided (see #186). That does leave the door open however for Data Packages that don't link to the same version of Camtrap DP across those 4 places.

This PR therefore enforces:

- The resource `schema` to be a string, i.e. URL/path. So embedded schemas won't be allowed anymore, which is good.
- That URL/path to contain the version number (using `pattern`), making it more likely that these are a URLs, which is what we want to. @niconoe this will likely require an update to test `Validate example against current schemas` 
- That all resources use the same version number in their path.

In order to allow this enforcement, the profile needs to know its own version number. I used the `$defs` approach to be able to define it close to the top of the file, rather than somewhere halfway. Note the `profile` property does not have the version number enforcement: it will always pass, because you can only trigger a validation by pointing the profile to the right file.

This implementation does add a slight burden to maintenance: **when creating a release on GitHub, we have to remember to also update the version number in the file**. Luckily, we only have to do it in one place.