### PR TITLE
Update license scope definition

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -31,10 +31,10 @@
             ],
             "properties": {
               "scope": {
-                "description": "Scope of the license. `data` for the license under which the content of the Data Package is provided, `media` for the license under which the media files referenced in `media.csv` are provided.",
+                "description": "Scope of the license. `data` applies to the content of the Data Package (`datapackage.json` and related CSV files), `media` applies to the media files (locally or externally hosted) referenced via `filePath` in the `media` resource.",
                 "enum": [
                   "data",
-                  "linked media"
+                  "media"
                 ] 
               }
             }

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -34,7 +34,7 @@
                 "description": "Scope of the license. `data` for the license under which the content of the Data Package is provided, `media` for the license under which the media files referenced in `media.csv` are provided.",
                 "enum": [
                   "data",
-                  "media"
+                  "linked media"
                 ] 
               }
             }

--- a/example/datapackage.json
+++ b/example/datapackage.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "http://creativecommons.org/licenses/by/4.0/",
-      "scope": "media"
+      "scope": "linked media"
     }
   ],
   "sources": [

--- a/example/datapackage.json
+++ b/example/datapackage.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "http://creativecommons.org/licenses/by/4.0/",
-      "scope": "linked media"
+      "scope": "media"
     }
   ],
   "sources": [


### PR DESCRIPTION
As suggested by @augusto-herrmann in https://github.com/tdwg/camtrap-dp/issues/189#issuecomment-1023193049, use the following terms in license scope:

```
data
linked media
```

The second was named `media`, which might be confusing that it is about the `media.csv` file rather than the media files referenced in `filePath` in `media.csv`. I opted for `linked media` (with space) in line with other vocab terms we have, such as `motion detection`.

Suggestions welcome.