### PR TITLE
Add AC terms as skos: links + inverse narrow/broad

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -100,9 +100,9 @@
           }
         },
         "rightsHolder": {
-          "description": "Person or organization owning or managing rights over the Data Package.",
+          "description": "Person or organization owning the rights over the Data Package.",
           "type": "string",
-          "skos:exactMatch": "http://purl.org/dc/terms/rightsHolder"
+          "skos:exactMatch": "http://ns.adobe.com/xap/1.0/rights/Owner"
         },
         "bibliographicCitation": {
           "description": "Bibliographic/recommended citation for the Data Package.",

--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -126,6 +126,7 @@
       "format": "default",
       "description": "Manufacturer and model of the camera provided in the format `manufacturer-model`.",
       "example": "Reconyx-PC800",
+      "skos:narrowMatch": "http://rs.tdwg.org/ac/terms/captureDevice",
       "constraints": {
         "required": false
       }
@@ -265,6 +266,7 @@
       "format": "default",
       "description": "User defined tags associated with the deployment, as a pipe (`|`) separated list.",
       "example": "Outside NP | Forest edge",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/tag",
       "constraints": {
         "required": false
       }

--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -9,7 +9,7 @@
       "format": "default",
       "description": "Unique identifier (within a project) of the deployment.",
       "example": "dep1",
-      "skos:narrowMatch": "http://rs.tdwg.org/dwc/terms/eventID",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/eventID",
       "constraints": {
         "required": true,
         "unique": true
@@ -126,7 +126,7 @@
       "format": "default",
       "description": "Manufacturer and model of the camera provided in the format `manufacturer-model`.",
       "example": "Reconyx-PC800",
-      "skos:narrowMatch": "http://rs.tdwg.org/ac/terms/captureDevice",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/captureDevice",
       "constraints": {
         "required": false
       }
@@ -266,7 +266,7 @@
       "format": "default",
       "description": "User defined tags associated with the deployment, as a pipe (`|`) separated list.",
       "example": "Outside NP | Forest edge",
-      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/tag",
+      "skos:narrowMatch": "http://rs.tdwg.org/ac/terms/tag",
       "constraints": {
         "required": false
       }

--- a/media-table-schema.json
+++ b/media-table-schema.json
@@ -83,7 +83,7 @@
       "name": "fileName",
       "type": "string",
       "format": "default",
-      "description": "Name of a media file. If provided, one should be able to sort media chronologically within a deployment on `timestamp` (first) and `fileName` (second).",
+      "description": "Name of the media file. If provided, one should be able to sort media chronologically within a deployment on `timestamp` (first) and `fileName` (second).",
       "example": "IMG0001.jpg",
       "constraints": {
         "required": false
@@ -93,7 +93,7 @@
       "name": "fileMediatype",
       "type": "string",
       "format": "default",
-      "description": "Mediatype of a media file.",
+      "description": "Mediatype of the file.",
       "example": "image/jpeg",
       "constraints": {
         "required": true

--- a/media-table-schema.json
+++ b/media-table-schema.json
@@ -9,7 +9,7 @@
       "format": "default",
       "description": "Unique identifier (within a project) of the media file.",
       "example": "m1",
-      "skos:narrowMatch": "http://purl.org/dc/terms/identifier",
+      "skos:broadMatch": "http://purl.org/dc/terms/identifier",
       "constraints": {
         "required": true,
         "unique": true
@@ -21,7 +21,7 @@
       "format": "default",
       "description": "Unique identifier of the deployment the observation belongs to. Foreign key to `deployment:deploymentID`.",
       "example": "dep1",
-      "skos:narrowMatch": "http://rs.tdwg.org/dwc/terms/eventID",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/eventID",
       "constraints": {
         "required": true
       }
@@ -32,7 +32,7 @@
       "format": "default",
       "description": "Unique identifier (within a project) of the sequence the media file belongs to. Sequences contain one or more media files (e.g. a single image or video or a sequence of successive images or videos) and are defined by `sequenceInterval` in the Data Package metadata.",
       "example": "seq1",
-      "skos:narrowMatch": "http://rs.tdwg.org/dwc/terms/eventID",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/eventID",
       "constraints": {
         "required": true
       }
@@ -43,7 +43,7 @@
       "format": "default",
       "description": "Method used to capture the media file.",
       "example": "motion detection",
-      "skos:narrowMatch": "http://rs.tdwg.org/ac/terms/resourceCreationTechnique",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/resourceCreationTechnique",
       "constraints": {
         "required": false,
         "enum": [
@@ -73,7 +73,7 @@
         "gs://wildlife_insights/Project/Images/CT-011/IMG0001.jpg",
         "DEP0001/IMG0001.jpg"
       ],
-      "skos:narrowMatch": "http://rs.tdwg.org/ac/terms/accessURI",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/accessURI",
       "constraints": {
         "required": true,
         "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$"

--- a/media-table-schema.json
+++ b/media-table-schema.json
@@ -9,6 +9,7 @@
       "format": "default",
       "description": "Unique identifier (within a project) of the media file.",
       "example": "m1",
+      "skos:narrowMatch": "http://purl.org/dc/terms/identifier",
       "constraints": {
         "required": true,
         "unique": true
@@ -42,6 +43,7 @@
       "format": "default",
       "description": "Method used to capture the media file.",
       "example": "motion detection",
+      "skos:narrowMatch": "http://rs.tdwg.org/ac/terms/resourceCreationTechnique",
       "constraints": {
         "required": false,
         "enum": [
@@ -56,6 +58,7 @@
       "format": "%Y-%m-%dT%H:%M:%S%z",
       "description": "Date and time when the media file was recorded, as an ISO 8601 formatted string with timezone designator (`YYYY-MM-DDThh:mm:ssZ` or `YYYY-MM-DDThh:mm:ss±hh:mm`).",
       "example": "2020-03-24T11:21:46Z",
+      "skos:exactMatch": "http://ns.adobe.com/xap/1.0/CreateDate",
       "constraints": {
         "required": true
       }
@@ -70,6 +73,7 @@
         "gs://wildlife_insights/Project/Images/CT-011/IMG0001.jpg",
         "DEP0001/IMG0001.jpg"
       ],
+      "skos:narrowMatch": "http://rs.tdwg.org/ac/terms/accessURI",
       "constraints": {
         "required": true,
         "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$"
@@ -131,6 +135,7 @@
       "format": "default",
       "description": "Unique identifier of the media file as assigned by the data management system.",
       "example": "",
+      "skos:exactMatch": "http://rs.tdwg.org/ac/terms/comments",
       "constraints": {
         "required": false
       }

--- a/media-table-schema.json
+++ b/media-table-schema.json
@@ -125,6 +125,7 @@
       "format": "default",
       "description": "Comments or notes about the media file.",
       "example": "corrupted file",
+      "skos:exactMatch": "http://rs.tdwg.org/ac/terms/comments",
       "constraints": {
         "required": false
       }
@@ -135,7 +136,6 @@
       "format": "default",
       "description": "Unique identifier of the media file as assigned by the data management system.",
       "example": "",
-      "skos:exactMatch": "http://rs.tdwg.org/ac/terms/comments",
       "constraints": {
         "required": false
       }

--- a/media-table-schema.json
+++ b/media-table-schema.json
@@ -136,6 +136,7 @@
       "format": "default",
       "description": "Unique identifier of the media file as assigned by the data management system.",
       "example": "",
+      "skos:exactMatch": "http://rs.tdwg.org/ac/terms/providerManagedID",
       "constraints": {
         "required": false
       }

--- a/observations-table-schema.json
+++ b/observations-table-schema.json
@@ -43,6 +43,7 @@
       "format": "default",
       "description": "Unique identifier of the media file that is the source of the observation. Foreign key to `media:mediaID`. Leave empty for sequence-based observations.",
       "example": "m1",
+      "skos:broadMatch": "http://purl.org/dc/terms/identifier",
       "constraints": {
         "required": false
       }

--- a/observations-table-schema.json
+++ b/observations-table-schema.json
@@ -21,7 +21,7 @@
       "format": "default",
       "description": "Unique identifier of the deployment the observation belongs to. Foreign key to `deployment:deploymentID`.",
       "example": "dep1",
-      "skos:narrowMatch": "http://rs.tdwg.org/dwc/terms/eventID",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/eventID",
       "constraints": {
         "required": true
       }
@@ -32,7 +32,7 @@
       "format": "default",
       "description": "Unique identifier of the sequence (collection of media files grouped by a predefined `sequenceInterval`) that is the source of the observation. Foreign key to `media:sequenceID`.",
       "example": "seq1",
-      "skos:narrowMatch": "http://rs.tdwg.org/dwc/terms/eventID",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/eventID",
       "constraints": {
         "required": true
       }


### PR DESCRIPTION
Adds AC links discussed in #191 (2 pending). Also reverses interpretation of narrow/broad, which was incorrect before: see https://github.com/tdwg/camtrap-dp/issues/191#issuecomment-1028208259 regarding our previously incorrect interpretation of broad/narrowMatch. A broadMatch B means: A has a broader concept called B.

## In this PR

- **updated** `metadata:rightsHolder` has exact match http://ns.adobe.com/xap/1.0/rights/Owner which accepts literal values, while previous dc:rightsHolder does not
- **updated** `dep:deploymentID`, `media:deploymentID`, `obs:deploymentID` has a broader match http://rs.tdwg.org/dwc/terms/eventID, deploymentID is more specific
- **updated** `media:sequenceID`, `obs:sequenceID` has a broader match http://rs.tdwg.org/dwc/terms/eventID, sequenceID is more specific
- **new** `dep:cameraModel` has a broader match http://rs.tdwg.org/ac/terms/captureDevice, cameraModel is more specific, since it requires it to be manufacturer-model
- **new** `dep:tags` has a narrower match http://rs.tdwg.org/ac/terms/tag, our deployment tags are broader then AC tags, which maybe relate to images only. **Hesitant about this, maybe it should be `exactMatch`?** @baskaufs @danstowell?
- **new** `media:mediaID`, `obs:mediaID` has a broader match http://purl.org/dc/terms/identifier, mediaID is more specific
- **new** `media:captureMethod` has a broader match http://rs.tdwg.org/ac/terms/resourceCreationTechnique, captureMethod only allows two values and is more specific
- **new**: `media:timestamp` has an exact match http://ns.adobe.com/xap/1.0/CreateDate
- **new**: `media:filePath` has a broad match http://rs.tdwg.org/ac/terms/accessURI, filePath relates to media files access URI only and is thus more specific
- **new**: `media:comments` has an exact match http://rs.tdwg.org/ac/terms/comments
- **new**: `media:_id` has an exact match http://rs.tdwg.org/ac/terms/providerManagedID 

## Pending

- **pending**: `dep:_id`, `media:_id`, `obs:_id` is this an exactmatch of http://rs.tdwg.org/ac/terms/providerManagedID @baskaufs @danstowell? For context, see https://github.com/tdwg/camtrap-dp/issues/191#issuecomment-1022173750 **Only do media:_id**
- **pending**: `obs:observationtype` is this a [Subject category](https://ac.tdwg.org/termlist/#Iptc4xmpExt_CVterm) @baskaufs @danstowell? For context, see https://github.com/tdwg/camtrap-dp/issues/191#issuecomment-1022173750 **Wait until resolved in AC**
