### PR TITLE
Avoid duplicate anchors

### DIFF
--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -16,8 +16,9 @@ layout: base
     {% for p1_raw in properties1 %}
       {% assign p1_name = p1_raw[0] %}
       {% assign p1 = p1_raw[1] %}
+      {% assign p1_id = p1_name | downcase | url_encode %}
       
-      <h2 id="{{ p1_name | downcase | url_encode }}">
+      <h2 id="{{ p1_id }}">
         {{ p1_name }}
         {% if required1 contains p1_name %}*{% endif %}
       </h2>
@@ -60,10 +61,11 @@ layout: base
             {% for p2_raw in properties2 %}
               {% assign p2_name = p2_raw[0] %}
               {% assign p2 = p2_raw[1] %}
+              {% assign p2_id = p2_name | downcase | url_encode %}
 
               <tr>
-                <td id="{{ p2_name | downcase | url_encode }}">
-                  <a href="#{{ p2_name | downcase | url_encode }}"><code>{{ p2_name }}</code></a>
+                <td id="{{ p1_id }}.{{ p2_id }}">
+                  <a href="#{{ p1_id }}.{{ p2_id }}"><code>{{ p2_name }}</code></a>
                   {% if required2 contains p2_name %}*{% endif %}
                 </td>
                 <td>

--- a/_layouts/tables.html
+++ b/_layouts/tables.html
@@ -9,8 +9,9 @@ layout: base
 
     {% for table_schema_file in site.data["_tables"] %}
       {% assign table_schema = site.data[table_schema_file] %}
+      {% assign table_schema_id = table_schema.title | downcase | url_encode %}
 
-      <h2 id="{{ table_schema.title | downcase | url_encode }}">{{ table_schema.title }}</h2>
+      <h2 id="{{ table_schema_id }}">{{ table_schema.title }}</h2>
 
       <p class="small">Source: <a href="https://github.com/{{ site.github_username }}/blob/main/{{ table_schema_file }}.json"><code>{{ table_schema_file }}.json</code></a></p>
 
@@ -34,8 +35,8 @@ layout: base
           </colgroup>
           {% for field in table_schema.fields %}
             <tr>
-              <td id="{{ field.name | downcase | url_encode }}">
-                <a href="#{{ field.name | downcase | url_encode }}"><code>{{ field.name }}</code></a>
+              <td id="{{ table_schema_id }}.{{ field.name | downcase | url_encode }}">
+                <a href="#{{ table_schema_id }}.{{ field.name | downcase | url_encode }}"><code>{{ field.name }}</code></a>
                 {% if field.constraints.required %}*{% endif %}
               </td>
               <td>


### PR DESCRIPTION
Makes sure each term on the website has a unique anchor, by prepending the table/property name with the term name (e.g. `#media.comments`). Fix #199