### PR TITLE
Add higher classification in taxonomic coverage

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -328,7 +328,7 @@
                 "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/genus"
               },
               "vernacularNames": {
-                "description": "Common or vernacular names of the taxon, as `languageCode: name` pairs. Language code should follow ISO 639-1 (e.g. `en` for English).",
+                "description": "Common or vernacular names of the taxon, as `languageCode: vernacular name` pairs. Language code should follow ISO 639-1 (e.g. `en` for English).",
                 "example": "{'en': 'wolf', 'fr': 'loup gris'}",
                 "type": "object",
                 "patternProperties": {

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -280,6 +280,7 @@
                   "class",
                   "order",
                   "family",
+                  "subfamily",
                   "genus",
                   "species",
                   "subspecies"

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -285,6 +285,48 @@
                   "subspecies"
                 ]
               },
+              "kingdom": {
+                "description": "Kingdom in which the taxon is classified.",
+                "example": "Animalia",
+                "type": "string",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/kingdom"
+              },
+              "phylum": {
+                "description": "Phylum or division in which the taxon is classified",
+                "example": "Chordata",
+                "type": "string",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/phylum"
+              },
+              "class": {
+                "description": "Class in which the taxon is classified.",
+                "example": "Mammalia",
+                "type": "string",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/class"
+              },
+              "order": {
+                "description": "Order in which the taxon is classified.",
+                "example": "Carnivora",
+                "type": "string",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/order"
+              },
+              "family": {
+                "description": "Family in which the taxon is classified.",
+                "example": "Canidae",
+                "type": "string",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/family"
+              },
+              "subfamily": {
+                "description": "Subfamily in which the taxon is classified.",
+                "example": "",
+                "type": "string",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/subfamily"
+              },
+              "genus": {
+                "description": "Genus in which the taxon is classified.",
+                "example": "Canis",
+                "type": "string",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/genus"
+              },
               "vernacularNames": {
                 "description": "Common or vernacular names of the taxon, as `languageCode: name` pairs. Language code should follow ISO 639-1 (e.g. `en` for English).",
                 "example": "{'en': 'wolf', 'fr': 'loup gris'}",

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -280,7 +280,6 @@
                   "class",
                   "order",
                   "family",
-                  "subfamily",
                   "genus",
                   "species",
                   "subspecies"
@@ -315,12 +314,6 @@
                 "example": "Canidae",
                 "type": "string",
                 "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/family"
-              },
-              "subfamily": {
-                "description": "Subfamily in which the taxon is classified.",
-                "example": "",
-                "type": "string",
-                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/subfamily"
               },
               "genus": {
                 "description": "Genus in which the taxon is classified.",


### PR DESCRIPTION
Fix #228.
- As described in that issue, the 7 ranks are included after `taxonRank` but before `vernacularNames`.
- I kept the example at Canis lupus, which does not have a subfamily, so I left the example empty for `subfamily`.  @kbubnicki should I update to a scientific name that does have a subfamily?
- I added subfamily as an accepted rank for the scientific rank.
