### PR TITLE
Reduce examples to a single value to fix frictionless validation

### DIFF
--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -102,10 +102,7 @@
       "type": "string",
       "format": "default",
       "description": "Name or unique identifier of the person who set up the camera for the deployment.",
-      "example": [
-        "Jim Casaer",
-        "2ef60d48-fd67-4bac-9569-49a03b0ef096"
-      ],
+      "example": "Jakub Bubnicki",
       "constraints": {
         "required": false
       }

--- a/example/datapackage.json
+++ b/example/datapackage.json
@@ -1,7 +1,7 @@
 {
   "name": "mica-muskrat-and-coypu-20210707160815",
   "id": "https://doi.org/10.5281/zenodo.4893244",
-  "profile": "https://raw.githubusercontent.com/tdwg/camtrap-dp/0.1.7/camtrap-dp-profile.json",
+  "profile": "https://raw.githubusercontent.com/tdwg/camtrap-dp/0.2/camtrap-dp-profile.json",
   "created": "2021-07-07T16:08:15Z",
   "licenses": [
     {
@@ -295,7 +295,7 @@
       "format": "csv",
       "mediatype": "text/csv",
       "encoding": "utf-8",
-      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/0.1.7/deployments-table-schema.json"
+      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/0.2/deployments-table-schema.json"
     },
     {
       "name": "media",
@@ -304,7 +304,7 @@
       "format": "csv",
       "mediatype": "text/csv",
       "encoding": "utf-8",
-      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/0.1.7/media-table-schema.json"
+      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/0.2/media-table-schema.json"
     },
     {
       "name": "observations",
@@ -313,7 +313,7 @@
       "format": "csv",
       "mediatype": "text/csv",
       "encoding": "utf-8",
-      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/0.1.7/observations-table-schema.json"
+      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/0.2/observations-table-schema.json"
     }
   ]
 }

--- a/media-table-schema.json
+++ b/media-table-schema.json
@@ -68,11 +68,7 @@
       "type": "string",
       "format": "default",
       "description": "URL or relative path to the media file, respectively for externally hosted files or files that are part of the Data Package.",
-      "example": [
-        "https://trapper.org/storage/resource/media/259024/file/",
-        "gs://wildlife_insights/Project/Images/CT-011/IMG0001.jpg",
-        "DEP0001/IMG0001.jpg"
-      ],
+      "example": "https://multimedia.agouti.eu/assets/6d65f3e4-4770-407b-b2bf-878983bf9872/file",
       "skos:broadMatch": "http://rs.tdwg.org/ac/terms/accessURI",
       "constraints": {
         "required": true,

--- a/observations-table-schema.json
+++ b/observations-table-schema.json
@@ -207,10 +207,7 @@
       "type": "string",
       "format": "default",
       "description": "Name or unique identifier of the person or AI algorithm that classified the observation.",
-      "example": [
-        "Jakub Bubnicki",
-        "Megadetector"
-      ],
+      "example": "MegaDetector V5",
       "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/identifiedBy",
       "constraints": {
         "required": false


### PR DESCRIPTION
Validation otherwise fails with latest version of frictionless, since examples are arrays rather than strings