### PR TITLE
Add table of content to data page

### DIFF
--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -43,8 +43,8 @@ layout: default
   {% if properties2 %}
   <table>
     <colgroup>
-      <col width="30%">
-      <col width="60%">
+      <col width="25%">
+      <col width="65%">
       <col width="10%">
     </colgroup>
     <thead>
@@ -74,6 +74,11 @@ layout: default
                 {% if p2.enum %}<li>enum: <code>{{ p2.enum | join: ", " }}</code></li>{% endif %}
                 {% if p2.items.enum %}<li>enum: <code>{{ p2.items.enum | join: ", " }}</code></li>{% endif %}
               </ul>
+            {% endif %}
+            {% if p2.example and p2.example != "" %}
+              <p>
+                <strong>Example</strong>: <code>{{ p2.example }}</code>
+              </p>
             {% endif %}
             {% if p2['skos:exactMatch'] %}
               <span class="small text-muted">Same as <a href="{{ p2['skos:exactMatch'] }}">{{ p2['skos:exactMatch'] }}</a></span>

--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -43,8 +43,8 @@ layout: default
   {% if properties2 %}
   <table>
     <colgroup>
-      <col width="20%">
-      <col width="70%">
+      <col width="30%">
+      <col width="60%">
       <col width="10%">
     </colgroup>
     <thead>
@@ -60,7 +60,7 @@ layout: default
         {% assign p2 = p2_raw[1] %}
         {% assign p2_id = p2_name | downcase | url_encode %}
 
-        <tr>
+        <tr class="text-break">
           <td id="{{ p1_id }}.{{ p2_id }}">
             <a href="#{{ p1_id }}.{{ p2_id }}"><code>{{ p2_name }}</code></a>
             {% if required2 contains p2_name %}*{% endif %}

--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -42,6 +42,11 @@ layout: default
 
   {% if properties2 %}
   <table>
+    <colgroup>
+      <col width="20%">
+      <col width="70%">
+      <col width="10%">
+    </colgroup>
     <thead>
       <tr>
         <th>Name</th>
@@ -50,42 +55,37 @@ layout: default
       </tr>
     </thead>
     <tbody>
-      <colgroup>
-        <col width="20%">
-        <col width="70%">
-        <col width="10%">
-      </colgroup>
-        {% for p2_raw in properties2 %}
-          {% assign p2_name = p2_raw[0] %}
-          {% assign p2 = p2_raw[1] %}
-          {% assign p2_id = p2_name | downcase | url_encode %}
+      {% for p2_raw in properties2 %}
+        {% assign p2_name = p2_raw[0] %}
+        {% assign p2 = p2_raw[1] %}
+        {% assign p2_id = p2_name | downcase | url_encode %}
 
-          <tr>
-            <td id="{{ p1_id }}.{{ p2_id }}">
-              <a href="#{{ p1_id }}.{{ p2_id }}"><code>{{ p2_name }}</code></a>
-              {% if required2 contains p2_name %}*{% endif %}
-            </td>
-            <td>
-              {{ p2.description | markdownify }}
-              {% if p2.const or p2.enum or p2.items.enum %}
-                <strong>Constraints</strong>
-                <ul>
-                  {% if p2.const %}<li>const: <code>{{ p2.const }}</code></li>{% endif %}
-                  {% if p2.enum %}<li>enum: <code>{{ p2.enum | join: ", " }}</code></li>{% endif %}
-                  {% if p2.items.enum %}<li>enum: <code>{{ p2.items.enum | join: ", " }}</code></li>{% endif %}
-                </ul>
-              {% endif %}
-              {% if p2['skos:exactMatch'] %}
-                <span class="small text-muted">Same as <a href="{{ p2['skos:exactMatch'] }}">{{ p2['skos:exactMatch'] }}</a></span>
-              {% elsif p2['skos:narrowMatch'] %}
-                <span class="small text-muted">Narrower than <a href="{{ p2['skos:narrowMatch'] }}">{{ p2['skos:narrowMatch'] }}</a></span>
-              {% elsif p2['skos:broadMatch'] %}
-                <span class="small text-muted">Broader than <a href="{{ p2['skos:broadMatch'] }}">{{ p2['skos:broadMatch'] }}</a></span>
-              {% endif %}
-            </td>
-            <td>{{ p2.type }}</td>
-          </tr>
-        {% endfor %}
+        <tr>
+          <td id="{{ p1_id }}.{{ p2_id }}">
+            <a href="#{{ p1_id }}.{{ p2_id }}"><code>{{ p2_name }}</code></a>
+            {% if required2 contains p2_name %}*{% endif %}
+          </td>
+          <td>
+            {{ p2.description | markdownify }}
+            {% if p2.const or p2.enum or p2.items.enum %}
+              <strong>Constraints</strong>
+              <ul>
+                {% if p2.const %}<li>const: <code>{{ p2.const }}</code></li>{% endif %}
+                {% if p2.enum %}<li>enum: <code>{{ p2.enum | join: ", " }}</code></li>{% endif %}
+                {% if p2.items.enum %}<li>enum: <code>{{ p2.items.enum | join: ", " }}</code></li>{% endif %}
+              </ul>
+            {% endif %}
+            {% if p2['skos:exactMatch'] %}
+              <span class="small text-muted">Same as <a href="{{ p2['skos:exactMatch'] }}">{{ p2['skos:exactMatch'] }}</a></span>
+            {% elsif p2['skos:narrowMatch'] %}
+              <span class="small text-muted">Narrower than <a href="{{ p2['skos:narrowMatch'] }}">{{ p2['skos:narrowMatch'] }}</a></span>
+            {% elsif p2['skos:broadMatch'] %}
+              <span class="small text-muted">Broader than <a href="{{ p2['skos:broadMatch'] }}">{{ p2['skos:broadMatch'] }}</a></span>
+            {% endif %}
+          </td>
+          <td>{{ p2.type }}</td>
+        </tr>
+      {% endfor %}
     </tbody>
   </table>
   {% endif %}

--- a/_layouts/tables.html
+++ b/_layouts/tables.html
@@ -1,74 +1,69 @@
 ---
-layout: base
+layout: default
 ---
 
-<div class="row">
-  <div class="col">
+{{ content }}
 
-    {{ content }}
+{% for table_schema_file in site.data["_tables"] %}
+  {% assign table_schema = site.data[table_schema_file] %}
+  {% assign table_schema_id = table_schema.title | downcase | url_encode %}
 
-    {% for table_schema_file in site.data["_tables"] %}
-      {% assign table_schema = site.data[table_schema_file] %}
-      {% assign table_schema_id = table_schema.title | downcase | url_encode %}
+  <h2 id="{{ table_schema_id }}">{{ table_schema.title }}</h2>
 
-      <h2 id="{{ table_schema_id }}">{{ table_schema.title }}</h2>
+  <p class="small">Source: <a href="https://github.com/{{ site.github_username }}/blob/main/{{ table_schema_file }}.json"><code>{{ table_schema_file }}.json</code></a></p>
 
-      <p class="small">Source: <a href="https://github.com/{{ site.github_username }}/blob/main/{{ table_schema_file }}.json"><code>{{ table_schema_file }}.json</code></a></p>
-
-      {{ table_schema.description | markdownify }}
-      
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Definition</th>
-            <th>Type</th>
-            <th>Example</th>
-          </tr>
-        </thead>
-        <tbody>
-          <colgroup>
-            <col width="20%">
-            <col width="50%">
-            <col width="10%">
-            <col width="20%">
-          </colgroup>
-          {% for field in table_schema.fields %}
-            <tr>
-              <td id="{{ table_schema_id }}.{{ field.name | downcase | url_encode }}">
-                <a href="#{{ table_schema_id }}.{{ field.name | downcase | url_encode }}"><code>{{ field.name }}</code></a>
-                {% if field.constraints.required %}*{% endif %}
-              </td>
-              <td>
-                {{ field.description | markdownify }}
-                {% if field.constraints %}
-                  <strong>Constraints</strong>
-                  <ul>
-                    {% for constraint in field.constraints %}
-                      <li>{{ constraint[0] }}: <code>{{ constraint[1] | join: ", " }}</code></li>
-                    {% endfor %}
-                  </ul>
-                {% endif %}
-                {% if field['skos:exactMatch'] %}
-                  <span class="small text-muted">Same as <a href="{{ field['skos:exactMatch'] }}">{{ field['skos:exactMatch'] }}</a></span>
-                {% elsif field['skos:narrowMatch'] %}
-                  <span class="small text-muted">Narrower than <a href="{{ field['skos:narrowMatch'] }}">{{ field['skos:narrowMatch'] }}</a></span>
-                {% elsif field['skos:broadMatch'] %}
-                  <span class="small text-muted">Broader than <a href="{{ field['skos:broadMatch'] }}">{{ field['skos:broadMatch'] }}</a></span>
-                {% endif %}
-              </td>
-              <td>{{ field.type }}</td>
-              <td>
-                {% if field.example %}
-                  {% for example in field.example %}
-                  <p><code>{{ example }}</code></p>
-                  {% endfor %}
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    {% endfor %}
-  </div>
-</div>
+  {{ table_schema.description | markdownify }}
+  
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Definition</th>
+        <th>Type</th>
+        <th>Example</th>
+      </tr>
+    </thead>
+    <tbody>
+      <colgroup>
+        <col width="20%">
+        <col width="50%">
+        <col width="10%">
+        <col width="20%">
+      </colgroup>
+      {% for field in table_schema.fields %}
+        <tr>
+          <td id="{{ table_schema_id }}.{{ field.name | downcase | url_encode }}">
+            <a href="#{{ table_schema_id }}.{{ field.name | downcase | url_encode }}"><code>{{ field.name }}</code></a>
+            {% if field.constraints.required %}*{% endif %}
+          </td>
+          <td>
+            {{ field.description | markdownify }}
+            {% if field.constraints %}
+              <strong>Constraints</strong>
+              <ul>
+                {% for constraint in field.constraints %}
+                  <li>{{ constraint[0] }}: <code>{{ constraint[1] | join: ", " }}</code></li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+            {% if field['skos:exactMatch'] %}
+              <span class="small text-muted">Same as <a href="{{ field['skos:exactMatch'] }}">{{ field['skos:exactMatch'] }}</a></span>
+            {% elsif field['skos:narrowMatch'] %}
+              <span class="small text-muted">Narrower than <a href="{{ field['skos:narrowMatch'] }}">{{ field['skos:narrowMatch'] }}</a></span>
+            {% elsif field['skos:broadMatch'] %}
+              <span class="small text-muted">Broader than <a href="{{ field['skos:broadMatch'] }}">{{ field['skos:broadMatch'] }}</a></span>
+            {% endif %}
+          </td>
+          <td>{{ field.type }}</td>
+          <td>
+            {% if field.example %}
+              {% for example in field.example %}
+              <p><code>{{ example }}</code></p>
+              {% endfor %}
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endfor %}

--- a/_layouts/tables.html
+++ b/_layouts/tables.html
@@ -16,17 +16,15 @@ layout: default
   
   <table>
     <colgroup>
-      <col width="30%">
-      <col width="60%">
+      <col width="25%">
+      <col width="65%">
       <col width="10%">
-      <col width="20%">
     </colgroup>
     <thead>
       <tr>
         <th>Name</th>
         <th>Definition</th>
         <th>Type</th>
-        <th>Example</th>
       </tr>
     </thead>
     <tbody>
@@ -46,6 +44,11 @@ layout: default
                 {% endfor %}
               </ul>
             {% endif %}
+            {% if field.example and field.example != "" %}
+              <p>
+                <strong>Example</strong>: <code>{{ field.example }}</code>
+              </p>
+            {% endif %}
             {% if field['skos:exactMatch'] %}
               <span class="small text-muted">Same as <a href="{{ field['skos:exactMatch'] }}">{{ field['skos:exactMatch'] }}</a></span>
             {% elsif field['skos:narrowMatch'] %}
@@ -55,13 +58,6 @@ layout: default
             {% endif %}
           </td>
           <td>{{ field.type }}</td>
-          <td>
-            {% if field.example %}
-              {% for example in field.example %}
-              <p><code>{{ example }}</code></p>
-              {% endfor %}
-            {% endif %}
-          </td>
         </tr>
       {% endfor %}
     </tbody>

--- a/_layouts/tables.html
+++ b/_layouts/tables.html
@@ -16,8 +16,8 @@ layout: default
   
   <table>
     <colgroup>
-      <col width="20%">
-      <col width="50%">
+      <col width="30%">
+      <col width="60%">
       <col width="10%">
       <col width="20%">
     </colgroup>
@@ -31,7 +31,7 @@ layout: default
     </thead>
     <tbody>
       {% for field in table_schema.fields %}
-        <tr>
+        <tr class="text-break">
           <td id="{{ table_schema_id }}.{{ field.name | downcase | url_encode }}">
             <a href="#{{ table_schema_id }}.{{ field.name | downcase | url_encode }}"><code>{{ field.name }}</code></a>
             {% if field.constraints.required %}*{% endif %}

--- a/_layouts/tables.html
+++ b/_layouts/tables.html
@@ -15,6 +15,12 @@ layout: default
   {{ table_schema.description | markdownify }}
   
   <table>
+    <colgroup>
+      <col width="20%">
+      <col width="50%">
+      <col width="10%">
+      <col width="20%">
+    </colgroup>
     <thead>
       <tr>
         <th>Name</th>
@@ -24,12 +30,6 @@ layout: default
       </tr>
     </thead>
     <tbody>
-      <colgroup>
-        <col width="20%">
-        <col width="50%">
-        <col width="10%">
-        <col width="20%">
-      </colgroup>
       {% for field in table_schema.fields %}
         <tr>
           <td id="{{ table_schema_id }}.{{ field.name | downcase | url_encode }}">

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -209,7 +209,7 @@
           }
         },
         "coordinatePrecision": {
-          "description": "Minimum precision of the `deployments.latitude` and `deployments.longitude` (e.g. `0.001` for a minimum precision of 0.001 degree). Especially relevant when coordinates are rounded to protect sensitive species.",
+          "description": "Least precise coordinate precision of the `deployments.latitude` and `deployments.longitude` (least precise in case of mixed precision, e.g. `0.01` for coordinates of precision of 0.01 and 0.001 degree). Especially relevant when coordinates have been rounded to protect sensitive species.",
           "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/coordinatePrecision",
           "type": "number",
           "example": 0.001

--- a/pages/data.md
+++ b/pages/data.md
@@ -1,11 +1,8 @@
 ---
 layout: tables
 title: Data
-description: >
-  [Deployments](#deployments){: .btn .btn-primary }
-  [Media](#media){: .btn .btn-primary }
-  [Observations](#observations){: .btn .btn-primary }
 permalink: /data/
+toc: true
 ---
 
 Data in Camtrap DP are organized as three related resources (CSV files): `deployments`, `media` and `observations`. These [Tabular Data Resources](https://specs.frictionlessdata.io/tabular-data-resource/) are described as `resources` in the `datapackage.json` file (see [Metadata](../metadata)). The descriptions of their fields follow the [Table Schema](https://specs.frictionlessdata.io/table-schema/) specifications and are presented below in human-readable form. Fields indicated with `*` are required (i.e. cannot be empty).


### PR DESCRIPTION
Rather than 3 buttons on top, have side menu that sticks when scrolling, cf. the metadata page in #241. Since the width of the table is reduced, I moved the example below the constraints (rather than a separate column). Overall, I think the page is more readable and easier to navigate.

![Data-Camtrap-DP](https://user-images.githubusercontent.com/600993/194114769-1c577616-e229-4515-b909-ff334ed882e1.png)
