### PR TITLE
Create example page displaying media vs event obs

### DIFF
--- a/_data/deployments.csv
+++ b/_data/deployments.csv
@@ -1,0 +1,1 @@
+../example/deployments.csv

--- a/_data/media.csv
+++ b/_data/media.csv
@@ -1,0 +1,1 @@
+../example/media.csv

--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -6,5 +6,7 @@
   href: /metadata/
 - text: Data
   href: /data/
+- text: Example
+  href: /example/
 - text: GitHub
   href: https://github.com/tdwg/camtrap-dp

--- a/_data/observations.csv
+++ b/_data/observations.csv
@@ -1,0 +1,1 @@
+../example/observations.csv

--- a/_layouts/example.html
+++ b/_layouts/example.html
@@ -1,0 +1,115 @@
+---
+layout: base
+---
+
+<div class="row">
+  <div class="col">
+
+    {{ content }}
+
+    <p class="small">Source: <a href="https://github.com/{{ site.github_username }}/blob/main/example"><code>example dataset</code></a></p>
+
+    {% assign deployments = site.data.deployments %}
+    {% assign media = site.data.media %}
+    {% assign event_observations = site.data.observations %}
+
+    {% for dep in deployments %}
+      {% assign dep_id = dep.deploymentID %}  
+      <h2 id="{{ dep_id }}">Dep: {{ dep_id }}</h2>
+
+      <dl>
+        <dt>Location</dt>
+        <dd>
+          <code>{{ dep.locationName }}</code>
+          (<a href="https://www.google.com/maps/search/?api=1&query={{ dep.latitude }},{{ dep.longitude }}&zoom=12"><code>{{ dep.latitude }}, {{ dep.longitude }}</code></a>),
+          uncertainty: <code>{{ dep.coordinateUncertainty }}</code>m
+        <dd>
+        <dt>Duration</dt>
+        <dd>
+          <code>{{ dep.start }}</code> / <code>{{ dep.end }}</code>
+        </dd>
+        <dt>Camera setup</dt>
+        <dd>
+          interval: <code>{{ dep.cameraInterval }}</code>,
+          height: <code>{{ dep.cameraHeight }}</code>,
+          tilt: <code>{{ dep.cameraTilt }}</code>,
+          heading: <code>{{ dep.cameraHeading }}</code>
+        </dd>
+        <dt>Bait</dt>
+        <dd>
+          <code>{{ dep.baitUse }}</code>
+        </dd>
+      </dl>
+
+      {% assign dep_media = media | where: 'deploymentID', dep_id %}
+      {% assign dep_event_ids = dep_media | map: 'sequenceID' | uniq %}
+      {% for event_id in dep_event_ids %}
+        <h3 id="{{ event_id }}">Event: {{ event_id }}</h3>
+        {% assign event_media = dep_media | where: 'sequenceID', event_id %}
+        {% assign event_obs = event_observations | where: 'sequenceID', event_id %}
+        {% assign med_length = event_media | size %}
+        
+        <table class="table table-bordered table-sm">
+          <colgroup>
+            <col width="10%">
+            <col width="45%">
+            <col width="45%">
+          </colgroup>
+          <thead>
+            <tr>
+              <th>Media file</th>
+              <th>Media observation</th>
+              <th>Event observation</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for med in event_media %}
+              <tr>
+                <td>
+                  <a href="{{ med.filePath }}"><img src="{{ med.filePath }}" height="50" alt="{{ med.fileName }}" title="{{ med.timestamp }}"></a>
+                </td>
+                <td>
+                  {% for obs in event_obs %}
+                  <!-- TODO: take this info from media_obs %} -->
+                    <code>{{ obs.observationType }}</code>
+                    {% if obs.observationType == 'animal' %}
+                      <span class="badge rounded-pill bg-secondary">{{ obs.count }}</span>
+                      <em>{{ obs.scientificName }}</em>
+                      {% if obs.lifeStage and obs.sex %}
+                        ({{ obs.lifeStage }}, {{ obs.sex }})
+                      {% elsif obs.lifeStage %}
+                        ({{ obs.lifeStage }})
+                      {% elsif obs.sex %}
+                        ({{ obs.sex }})
+                      {% endif %}
+                    {% endif %}
+                    <br>
+                  {% endfor %}
+                </td>
+                {% if forloop.first %}
+                <td rowspan="{{ med_length }}">
+                  {% for obs in event_obs %}
+                    <code>{{ obs.observationType }}</code>
+                    {% if obs.observationType == 'animal' %}
+                      <span class="badge rounded-pill bg-secondary">{{ obs.count }}</span>
+                      <em>{{ obs.scientificName }}</em>
+                      {% if obs.lifeStage and obs.sex %}
+                        ({{ obs.lifeStage }}, {{ obs.sex }})
+                      {% elsif obs.lifeStage %}
+                        ({{ obs.lifeStage }})
+                      {% elsif obs.sex %}
+                        ({{ obs.sex }})
+                      {% endif %}
+                    {% endif %}
+                    <br>
+                  {% endfor %}
+                </td>
+                {% endif %}
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endfor %}
+    {% endfor %}
+  </div>
+</div>

--- a/pages/example.md
+++ b/pages/example.md
@@ -1,0 +1,5 @@
+---
+layout: example
+title: Example dataset
+permalink: /example/
+---


### PR DESCRIPTION
I think it would be useful to have an **example page** on the website, that shows the included [example dataset](https://github.com/tdwg/camtrap-dp/tree/main/example) in a more visual way. In this PR I've created a page that mainly shows the upcoming difference between media vs event observations (see screenshot below). It is organized in:

- h2 heading per deployment, showing some deployment info
- h3 heading for each event in deployment
- table with all media files in that event, with on the left media-observations and on the right event-observations. The information is currently repeated for media-obs, as the example dataset does not yet include a media-observation file.

Each heading has an anchor and can thus be referenced.
Each image has a link to open it

I would keep this PR in draft format until #203 is done, but feedback is welcome.

![Example-dataset-Camtrap-DP](https://user-images.githubusercontent.com/600993/209337831-ed8691bc-88c2-4da9-8394-a98d35e91987.png)
