### PR TITLE
Allow more (custom) tables + update tests

### DIFF
--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -36,6 +36,9 @@ layout: default
   {% elsif p1.items.properties %}
     {% assign properties2 = p1.items.properties %}
     {% assign required2 = p1.items.required %}
+  {% elsif p1.items.oneOf[0].properties %}
+    {% assign properties2 = p1.items.oneOf[0].properties %}
+    {% assign required2 = p1.items.oneOf[0].required %}
   {% else %}
     {% assign properties2 = false %}
   {% endif %}

--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -8,7 +8,7 @@ layout: default
 {% assign properties1 = site.data[profile_file].allOf[1].properties %}
 {% assign required1 = site.data[profile_file].allOf[1].required %}
 
-<p class="small">Source: <a href="https://github.com/{{ site.github_username }}/blob/main/{{ profile_file }}.json"><code>{{ profile_file }}.json</code></a></p>
+<p class="small">Source: <a href="{{ site.github.repository_url }}/blob/main/{{ profile_file }}.json"><code>{{ profile_file }}.json</code></a></p>
 
 {% for p1_raw in properties1 %}
   {% assign p1_name = p1_raw[0] %}

--- a/_layouts/tables.html
+++ b/_layouts/tables.html
@@ -10,7 +10,7 @@ layout: default
 
   <h2 id="{{ table_schema_id }}">{{ table_schema.title }}</h2>
 
-  <p class="small">Source: <a href="https://github.com/{{ site.github_username }}/blob/main/{{ table_schema_file }}.json"><code>{{ table_schema_file }}.json</code></a></p>
+  <p class="small">Source: <a href="{{ site.github.repository_url }}/blob/main/{{ table_schema_file }}.json"><code>{{ table_schema_file }}.json</code></a></p>
 
   {{ table_schema.description | markdownify }}
   

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -46,7 +46,15 @@
               },
               "schema": {
                 "description": "URL of the used Camtrap DP Table Schema version (e.g. `https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/deployments-table-schema.json`).",
-                "$ref": "#$defs/version"
+                "allOf": [
+                  {
+                    "$ref": "#$defs/version"
+                  },
+                  {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                ]
               }
             }
           }

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -27,35 +27,57 @@
           "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#resource-information). Camtrap DP further requires each object to be a [Tabular Data Resource](https://specs.frictionlessdata.io/tabular-data-resource/) with a specific `name` and `schema`. See [Data](../data) for the requirements for those resources.",
           "minItems": 3,
           "items": {
-            "required": [
-              "schema",
-              "profile"
-            ],
-            "properties": {
-              "name": {
-                "description": "Identifier of the resource.",
-                "enum": [
-                  "deployments",
-                  "media",
-                  "observations"
-                ]
-              },
-              "profile": {
-                "const": "tabular-data-resource"
-              },
-              "schema": {
-                "description": "URL of the used Camtrap DP Table Schema version (e.g. `https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/deployments-table-schema.json`).",
-                "allOf": [
-                  {
-                    "$ref": "#$defs/version"
+            "oneOf": [
+              {
+                "required": [
+                  "name",
+                  "path",
+                  "profile",
+                  "schema"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Identifier of the resource.",
+                    "enum": [
+                      "deployments",
+                      "media",
+                      "observations"
+                    ]
                   },
-                  {
-                    "type": "string",
-                    "format": "uri"
+                  "profile": {
+                    "const": "tabular-data-resource"
+                  },
+                  "schema": {
+                    "description": "URL of the used Camtrap DP Table Schema version (e.g. `https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/deployments-table-schema.json`).",
+                    "allOf": [
+                      {
+                        "$ref": "#$defs/version"
+                      },
+                      {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    ]
                   }
-                ]
+                }
+              },
+              {
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "not": {
+                      "enum": [
+                        "deployments",
+                        "media",
+                        "observations"
+                      ]
+                    }
+                  }
+                }
               }
-            }
+            ]
           }
         },
         "profile": {

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -44,7 +44,11 @@
                       "observations"
                     ]
                   },
+                  "path": {
+                    "description": "Path or URL to the data file."
+                  },
                   "profile": {
+                    "description": "[Profile](https://specs.frictionlessdata.io/profiles/) of the resource.",
                     "enum": [
                       "tabular-data-resource"
                     ]

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -46,19 +46,7 @@
               },
               "schema": {
                 "description": "URL of the used Camtrap DP Table Schema version (e.g. `https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/deployments-table-schema.json`).",
-                "$ref": "#$defs/version",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "enum": [
-                      "deployments",
-                      "media",
-                      "observations"
-                    ]
-                  }
-                }
+                "$ref": "#$defs/version"
               }
             }
           }

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -45,7 +45,9 @@
                     ]
                   },
                   "profile": {
-                    "const": "tabular-data-resource"
+                    "enum": [
+                      "tabular-data-resource"
+                    ]
                   },
                   "schema": {
                     "description": "URL of the used Camtrap DP Table Schema version (e.g. `https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/deployments-table-schema.json`).",

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -26,7 +26,6 @@
         "resources": {
           "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#resource-information). Camtrap DP further requires each object to be a [Tabular Data Resource](https://specs.frictionlessdata.io/tabular-data-resource/) with a specific `name` and `schema`. See [Data](../data) for the requirements for those resources.",
           "minItems": 3,
-          "maxItems": 3,
           "items": {
             "required": [
               "schema",

--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -1,5 +1,4 @@
 {
-  "name": "deployments",
   "title": "Deployments",
   "description": "Table with camera trap deployments. Includes `deploymentID`, start, end, location and camera setup information.",
   "fields": [

--- a/example/datapackage.json
+++ b/example/datapackage.json
@@ -26,6 +26,17 @@
       "mediatype": "text/csv",
       "encoding": "utf-8",
       "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/0.6/observations-table-schema.json"
+    },
+    {
+      "name": "individuals",
+      "description": "Custom table/resource not part of the Camtrap DP model. Included to showcase that extending with more resources is possible.",
+      "data": [
+        {
+          "id": 1,
+          "individualName": "Reinaert",
+          "scientificName": "Vulpes vulpes"
+        }
+      ]
     }
   ],
   "profile": "https://raw.githubusercontent.com/tdwg/camtrap-dp/0.6/camtrap-dp-profile.json",

--- a/media-table-schema.json
+++ b/media-table-schema.json
@@ -1,5 +1,4 @@
 {
-  "name": "media",
   "title": "Media",
   "description": "Table with media files (images/videos) captured by the camera traps. Associated with deployments (`deploymentID`) and organized in events (`eventID`). Includes timestamp and file path.",
   "fields": [

--- a/observations-table-schema.json
+++ b/observations-table-schema.json
@@ -1,5 +1,4 @@
 {
-  "name": "observations",
   "title": "Observations",
   "description": "Table with observations that are classified at event level. Associated with media files via `eventID`. Observations can mark non-animal events (camera setup, human, blank) or one or more animal observations (`observationType` = `animal`) of a certain taxon, count, life stage, sex, behavior and/or individual.",
   "fields": [

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 from pprint import pprint
+from typing import Optional, List
+
 from frictionless import validate_package
 
 THIS_SCRIPT_PATH = Path(__file__).parent
@@ -14,8 +16,15 @@ TABLE_SCHEMA_PATHS = [
     REPOSITORY_ROOT_PATH / "observations-table-schema.json"
 ]
 
-def validate_package_print_and_exit(descriptor_data: dict) -> None:
+
+def validate_package_print_and_exit(descriptor_data: dict, paths_to_delete: Optional[List] = None) -> None:
     report = validate_package(descriptor_data)
+
+    # Cleanup
+    if paths_to_delete is not None:
+        for path in paths_to_delete:
+            path.unlink()
+
     if report.valid:
         print("✔︎ valid package")
         sys.exit(0)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,6 +7,7 @@ THIS_SCRIPT_PATH = Path(__file__).parent
 REPOSITORY_ROOT_PATH = THIS_SCRIPT_PATH / ".."
 EXAMPLE_PATH = REPOSITORY_ROOT_PATH / "example" / "datapackage.json"
 PROFILE_PATH = REPOSITORY_ROOT_PATH / "camtrap-dp-profile.json"
+RELAXED_PROFILE_PATH = REPOSITORY_ROOT_PATH / "camtrap-dp-profile-relaxed.json" # File created in later step
 TABLE_SCHEMA_PATHS = [
     REPOSITORY_ROOT_PATH / "deployments-table-schema.json",
     REPOSITORY_ROOT_PATH / "media-table-schema.json",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,6 @@ import sys
 from pathlib import Path
 from pprint import pprint
 from typing import Optional, List
-
 from frictionless import validate_package
 
 THIS_SCRIPT_PATH = Path(__file__).parent
@@ -15,7 +14,6 @@ TABLE_SCHEMA_PATHS = [
     REPOSITORY_ROOT_PATH / "media-table-schema.json",
     REPOSITORY_ROOT_PATH / "observations-table-schema.json"
 ]
-
 
 def validate_package_print_and_exit(descriptor_data: dict, paths_to_delete: Optional[List] = None) -> None:
     report = validate_package(descriptor_data)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,13 +1,17 @@
 import sys
 from pathlib import Path
 from pprint import pprint
-
-from frictionless import validate_package  # type: ignore
+from frictionless import validate_package
 
 THIS_SCRIPT_PATH = Path(__file__).parent
 REPOSITORY_ROOT_PATH = THIS_SCRIPT_PATH / ".."
-EXAMPLE_DESCRIPTOR_PATH = REPOSITORY_ROOT_PATH / "example" / "datapackage.json"
-
+EXAMPLE_PATH = REPOSITORY_ROOT_PATH / "example" / "datapackage.json"
+PROFILE_PATH = REPOSITORY_ROOT_PATH / "camtrap-dp-profile.json"
+TABLE_SCHEMA_PATHS = [
+    REPOSITORY_ROOT_PATH / "deployments-table-schema.json",
+    REPOSITORY_ROOT_PATH / "media-table-schema.json",
+    REPOSITORY_ROOT_PATH / "observations-table-schema.json"
+]
 
 def validate_package_print_and_exit(descriptor_data: dict) -> None:
     report = validate_package(descriptor_data)

--- a/tests/validate_example_current_schema.py
+++ b/tests/validate_example_current_schema.py
@@ -1,38 +1,31 @@
-import json
-import os
+# This script validates the example dataset against the current Camtrap DP schemas
 
+import os
+import json
 from pathlib import Path
 from httpserver import ServeDirectoryWithHTTP
-from helpers import validate_package_print_and_exit, EXAMPLE_DESCRIPTOR_PATH, REPOSITORY_ROOT_PATH
-
-CURRENT_PACKAGE_PROFILE_PATH = Path(__file__).parent / ".." / "camtrap-dp-profile.json"
-
-RESOURCES_TO_PATCH = [
-    {'resource_name': 'deployments', 'current_schema_path': (REPOSITORY_ROOT_PATH / 'deployments-table-schema.json')},
-    {'resource_name': 'media', 'current_schema_path': REPOSITORY_ROOT_PATH / 'media-table-schema.json'},
-    {'resource_name': 'observations', 'current_schema_path': REPOSITORY_ROOT_PATH / 'observations-table-schema.json'}
-]
+from helpers import validate_package_print_and_exit, EXAMPLE_PATH, PROFILE_PATH, TABLE_SCHEMA_PATHS
 
 if __name__ == "__main__":
-    # We need to serve the current "camtrap-dp-profile.json" over an URL so it can be referenced in the descriptor
-    httpd, address = ServeDirectoryWithHTTP(CURRENT_PACKAGE_PROFILE_PATH.parent)
-    fixed_address = address.replace("1.0.0.127.in-addr.arpa", "localhost")
+    # Profile and schemas are referenced by URL in the descriptor (datapackage.json)
+    # Here we setup a local server to host the current profile and schemas
+    httpd, address = ServeDirectoryWithHTTP(PROFILE_PATH.parent)
+    server_address = address.replace("1.0.0.127.in-addr.arpa", "localhost")
 
-    with open(EXAMPLE_DESCRIPTOR_PATH) as json_file:
-        print(f"Validating {EXAMPLE_DESCRIPTOR_PATH} against current schemas")
+    with open(EXAMPLE_PATH) as json_file:
+        print(f"Validating {EXAMPLE_PATH} against current schemas")
         descriptor_data = json.load(json_file)
 
-        # In this case, we update the descriptor so it points to the current version
-        # 1. Replace profile URL with current one
-        descriptor_data['profile'] = f"{fixed_address}/camtrap-dp-profile.json"
-        # 2. Replace resources schemas with current one
-        for resource_to_patch in RESOURCES_TO_PATCH:
-            resource_index = next((i for i, item in enumerate(descriptor_data['resources']) if item["name"] == resource_to_patch['resource_name']), None)
-            with open(resource_to_patch['current_schema_path']) as schema_file:
-                descriptor_data['resources'][resource_index]['schema'] = json.load(schema_file)
+        # 1. Replace profile URL with local one
+        descriptor_data['profile'] = f"{server_address}/{PROFILE_PATH.name}"
+
+        # 2. Replace schema URLs of the resources with local ones
+        for table_schema in TABLE_SCHEMA_PATHS:
+            resource_index = next((i for i, item in enumerate(descriptor_data['resources']) if item["name"] == table_schema.name.split("-")[0]), None)
+            descriptor_data['resources'][resource_index]['schema'] = f"{server_address}/{table_schema.name}"
 
         # Frictionless loads resource relative to the current directory, (and not to the descriptor)
         # Issue reported to frictionless: https://github.com/frictionlessdata/frictionless-py/issues/956
-        os.chdir(EXAMPLE_DESCRIPTOR_PATH.parent)
+        os.chdir(EXAMPLE_PATH.parent)
 
         validate_package_print_and_exit(descriptor_data)

--- a/tests/validate_example_current_schema.py
+++ b/tests/validate_example_current_schema.py
@@ -4,13 +4,12 @@ import os
 import json
 import shutil
 import re
-from pathlib import Path
 from httpserver import ServeDirectoryWithHTTP
 from helpers import validate_package_print_and_exit, EXAMPLE_PATH, PROFILE_PATH, RELAXED_PROFILE_PATH, TABLE_SCHEMA_PATHS
 
 if __name__ == "__main__":
     # Profile and schemas are referenced by URL in the descriptor (datapackage.json)
-    # Here we setup a local server to host the current profile and schemas
+    # Here we set up a local server to host the current profile and schemas
     httpd, address = ServeDirectoryWithHTTP(PROFILE_PATH.parent)
     server_address = address.replace("1.0.0.127.in-addr.arpa", "localhost")
 
@@ -37,8 +36,4 @@ if __name__ == "__main__":
         # Issue reported to frictionless: https://github.com/frictionlessdata/frictionless-py/issues/956
         os.chdir(EXAMPLE_PATH.parent)
 
-        validate_package_print_and_exit(descriptor_data)
-
-        # Remove "relaxed" profile
-        # TODO: doesn't get deleted
-        RELAXED_PROFILE_PATH.unlink()
+        validate_package_print_and_exit(descriptor_data, paths_to_delete=[RELAXED_PROFILE_PATH])

--- a/tests/validate_example_current_schema.py
+++ b/tests/validate_example_current_schema.py
@@ -2,9 +2,11 @@
 
 import os
 import json
+import shutil
+import re
 from pathlib import Path
 from httpserver import ServeDirectoryWithHTTP
-from helpers import validate_package_print_and_exit, EXAMPLE_PATH, PROFILE_PATH, TABLE_SCHEMA_PATHS
+from helpers import validate_package_print_and_exit, EXAMPLE_PATH, PROFILE_PATH, RELAXED_PROFILE_PATH, TABLE_SCHEMA_PATHS
 
 if __name__ == "__main__":
     # Profile and schemas are referenced by URL in the descriptor (datapackage.json)
@@ -12,12 +14,19 @@ if __name__ == "__main__":
     httpd, address = ServeDirectoryWithHTTP(PROFILE_PATH.parent)
     server_address = address.replace("1.0.0.127.in-addr.arpa", "localhost")
 
+    # The profile file has a requirement that schema URLs should contain a version number
+    # Here we create a "relaxed" profile file where that requirement is changed
+    shutil.copyfile(PROFILE_PATH, RELAXED_PROFILE_PATH)
+    data = RELAXED_PROFILE_PATH.read_text()
+    data = re.sub('"pattern": ".*"', '"pattern": "localhost"', data) # Don't require version number, require "localhost"
+    RELAXED_PROFILE_PATH.write_text(data)
+
     with open(EXAMPLE_PATH) as json_file:
         print(f"Validating {EXAMPLE_PATH} against current schemas")
         descriptor_data = json.load(json_file)
 
-        # 1. Replace profile URL with local one
-        descriptor_data['profile'] = f"{server_address}/{PROFILE_PATH.name}"
+        # 1. Replace profile URL with "relaxed" local one
+        descriptor_data['profile'] = f"{server_address}/{RELAXED_PROFILE_PATH.name}"
 
         # 2. Replace schema URLs of the resources with local ones
         for table_schema in TABLE_SCHEMA_PATHS:
@@ -29,3 +38,7 @@ if __name__ == "__main__":
         os.chdir(EXAMPLE_PATH.parent)
 
         validate_package_print_and_exit(descriptor_data)
+
+        # Remove "relaxed" profile
+        # TODO: doesn't get deleted
+        RELAXED_PROFILE_PATH.unlink()

--- a/tests/validate_example_versioned_schema.py
+++ b/tests/validate_example_versioned_schema.py
@@ -1,15 +1,16 @@
-import json
-import os
+# This script validates the example dataset against the versioned Camtrap DP schemas
 
-from helpers import validate_package_print_and_exit, EXAMPLE_DESCRIPTOR_PATH
+import os
+import json
+from helpers import validate_package_print_and_exit, EXAMPLE_PATH
 
 if __name__ == "__main__":
     # Frictionless loads resource relative to the current directory, (and not to the descriptor)
     # Issue reported to frictionless: https://github.com/frictionlessdata/frictionless-py/issues/956
-    os.chdir(EXAMPLE_DESCRIPTOR_PATH.parent)
+    os.chdir(EXAMPLE_PATH.parent)
 
-    with open(EXAMPLE_DESCRIPTOR_PATH) as json_file:
-        print(f"Validating {EXAMPLE_DESCRIPTOR_PATH} against versioned schemas")
+    with open(EXAMPLE_PATH) as json_file:
+        print(f"Validating {EXAMPLE_PATH} against versioned schemas")
         descriptor_data = json.load(json_file)
         # In this case, we validate the package as-is
         validate_package_print_and_exit(descriptor_data)

--- a/tests/validate_profile_and_schemas.py
+++ b/tests/validate_profile_and_schemas.py
@@ -1,24 +1,11 @@
-# This script validate the Camtrap-dp standard itself is valid (regarding JSON and Frictionless definitions)
-import json
+# This script validates the Camtrap-DP standard itself is valid (regarding JSON and Frictionless definitions)
+
 import sys
+import json
 from pathlib import Path
 from typing import List
-
-from frictionless import Schema  # type: ignore
-
-from helpers import REPOSITORY_ROOT_PATH
-
-THIS_SCRIPT_PATH = Path(__file__).parent
-
-
-PACKAGE_PROFILE = REPOSITORY_ROOT_PATH / "camtrap-dp-profile.json"
-
-TABLES = [
-    REPOSITORY_ROOT_PATH / "media-table-schema.json",
-    REPOSITORY_ROOT_PATH / "deployments-table-schema.json",
-    REPOSITORY_ROOT_PATH / "observations-table-schema.json",
-]
-
+from frictionless import Schema
+from helpers import PROFILE_PATH, TABLE_SCHEMA_PATHS
 
 def validate_json(filepath: Path) -> bool:
     with open(filepath) as file:
@@ -29,42 +16,39 @@ def validate_json(filepath: Path) -> bool:
         else:
             return True
 
-
 def validate_schema(file_path: Path) -> bool:
     s = Schema(descriptor=file_path)
     return s.metadata_valid
 
-
 def get_schema_metadata_error_messages(file_path: Path) -> List[str]:
     """Return a list of error messages for the table schema at file_path
 
-    Undefined behaviour if the table schema is valid
+    Undefined behavior if the table schema is valid
     """
     s = Schema(descriptor=file_path)
     return [err.message for err in s.metadata_errors]
 
-
 if __name__ == "__main__":
     encountered_errors = False
 
-    print(PACKAGE_PROFILE.name)
-    result = validate_json(PACKAGE_PROFILE)
+    print(PROFILE_PATH.name)
+    result = validate_json(PROFILE_PATH)
     if result is True:
         print("✔︎ valid JSON")
     else:
         print("✕ valid JSON")
         encountered_errors = True
 
-    for table in TABLES:
-        print(f"\n{table.name}")
+    for table_schema in TABLE_SCHEMA_PATHS:
+        print(f"\n{table_schema.name}")
 
-        if validate_json(table):
+        if validate_json(table_schema):
             print("✔︎ valid JSON")
-            if validate_schema(table):
+            if validate_schema(table_schema):
                 print("✔︎ valid Table Schema")
             else:
                 print("✕ valid Table Schema, errors:")
-                for err in get_schema_metadata_error_messages(table):
+                for err in get_schema_metadata_error_messages(table_schema):
                     print(f"\t - {err}")
                 encountered_errors = True
         else:


### PR DESCRIPTION
Fix #272. This PR includes:

## Allow more than 3 tables

This will be required when we split `observations` and allow datasets to have either:
- `deployments`, `media`, `media-observations`
- `deployments`, `media`, `event-observations`
- `deployments`, `media`, `media-observations`, `event-observations`

## Updated validation for Camtrap DP tables

Note: the resource `schema` is expected to be `https://raw.githubusercontent.com/tdwg/camtrap-dp/<version>/deployments-table-schema.json` with `<version>` e.g. `0.6`. That guarantees that the data is validated against the official Camtrap DP schema

The following conditions will result in validation error:

1. Resource has no `name`
1. Resource has no `path`, but `data`: this is new, it requires Camtrap DP tables to be files, not inline data
1. Resource has no `profile`
1. Resource has `profile`, but it is not `tabular-data-package`
1. Resource has no `schema`
1. Resource `schema` is verbosely included, rather than a URL: this is new, as it was possible to by-pass this before
1. Resource `schema` is a URL, but does not contain the correct `<version>` number: this 1) makes it harder to spoof a URL and 2) makes sure that the metadata and data use the same version.
1. Resource name and schema don't match (e.g. `deployment` resource links to the `media` schema): this is allowed, but will result in table schema validation errors.

## Allow custom tables

The schema now also allows **custom** resources, as long as they don't have the reserved Camtrap DP table names. Other than that they should have a `name`, they are not further validated by Camtrap DP, but could rely on Frictionless validation.

## Updated testing

The stricter validation required updates to the test suite. To allow testing the example dataset against the current schemas in the repo:
- A http server is setup to spoof the URLs (was already setup by @niconoe)
- The table schemas are now also served from this server
- The `<version>` requirement in the profile is overwritten to `localhost` for the local tests 
