### PR TITLE
Add unit property

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Camera Trap Data Package",
-  "description": "Data exchange format for camera trap data. https://tdwg.github.io/camtrap-dp/",
+  "description": "Data exchange format for camera trap data. <https://tdwg.github.io/camtrap-dp/>",
   "type": "object",
   "$defs": {
     "version": {

--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -59,7 +59,7 @@
     },
     {
       "name": "coordinateUncertainty",
-      "description": "Horizontal distance in meters from the given `latitude` and `longitude` describing the smallest circle containing the deployment location. Especially relevant when coordinates are rounded to protect sensitive species.",
+      "description": "Horizontal distance from the given `latitude` and `longitude` describing the smallest circle containing the deployment location. Expressed in meters. Especially relevant when coordinates are rounded to protect sensitive species.",
       "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters",
       "type": "integer",
       "constraints": {

--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -66,6 +66,7 @@
         "required": false,
         "minimum": 1
       },
+      "unit": "m",
       "example": 100
     },
     {
@@ -137,6 +138,7 @@
         "required": false,
         "minimum": 0
       },
+      "unit": "m",
       "example": 1.2
     },
     {
@@ -148,6 +150,7 @@
         "minimum": -90,
         "maximum": 90
       },
+      "unit": "°",
       "example": -90
     },
     {
@@ -159,6 +162,7 @@
         "minimum": 0,
         "maximum": 360
       },
+      "unit": "°",
       "example": 225
     },
     {
@@ -169,6 +173,7 @@
         "required": false,
         "minimum": 0
       },
+      "unit": "m",
       "example": 9.5
     },
     {


### PR DESCRIPTION
Fix #290. Although the unit is always expressed in the definition (where applicable), I think it makes sense to indicate it as a separate property that can be picked up by software. So far we have 2 units. I indicated those as `unit: symbol_of_unit`:

- `m`: https://en.wikipedia.org/wiki/Metre
- `°`: https://en.wikipedia.org/wiki/Degree_(angle) (alternative `deg`)