### PR TITLE
Reintroduce names for table schemas

### DIFF
--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -13,7 +13,7 @@ layout: default
 {% for p1_raw in properties1 %}
   {% assign p1_name = p1_raw[0] %}
   {% assign p1 = p1_raw[1] %}
-  {% assign p1_id = p1_name | downcase | url_encode %}
+  {% assign p1_id = p1_name %}
   
   <h2 id="{{ p1_id }}">
     {{ p1_name }}
@@ -61,7 +61,7 @@ layout: default
       {% for p2_raw in properties2 %}
         {% assign p2_name = p2_raw[0] %}
         {% assign p2 = p2_raw[1] %}
-        {% assign p2_id = p2_name | downcase | url_encode %}
+        {% assign p2_id = p2_name %}
 
         <tr class="text-break">
           <td id="{{ p1_id }}.{{ p2_id }}">

--- a/_layouts/tables.html
+++ b/_layouts/tables.html
@@ -6,7 +6,7 @@ layout: default
 
 {% for table_schema_file in site.data["_tables"] %}
   {% assign table_schema = site.data[table_schema_file] %}
-  {% assign table_schema_id = table_schema.title | downcase | replace: ' ', '-' %}
+  {% assign table_schema_id = table_schema.name %}
 
   <h2 id="{{ table_schema_id }}">{{ table_schema.title }}</h2>
 

--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -1,4 +1,5 @@
 {
+  "name": "deployments",
   "title": "Deployments",
   "description": "Table with camera trap deployments. Includes `deploymentID`, start, end, location and camera setup information.",
   "fields": [

--- a/event-observations-table-schema.json
+++ b/event-observations-table-schema.json
@@ -1,4 +1,5 @@
 {
+  "name": "event-observations",
   "title": "Event observations",
   "description": "Table with observations that are classified at event level. Associated with media files via `eventID`. Observations can mark non-animal events (camera setup, human, blank) or one or more animal observations (`observationType` = `animal`) of a certain taxon, count, life stage, sex, behavior and/or individual. Event observations are required to be mutually exclusive, so that `count` can be summed.",
   "fields": [

--- a/example/datapackage.json
+++ b/example/datapackage.json
@@ -89,7 +89,7 @@
       "role": "publisher"
     }
   ],
-  "description": "MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany is an occurrence dataset published by the Research Institute of Nature and Forest (INBO). It is part of the LIFE project MICA, in which innovative techniques are tested for a more efficient control of muskrat and coypu populations, both invasive species. This dataset is a sample of the original dataset and serves as an example of a Camtrap Trap Data Package (Camtrap DP).",
+  "description": "MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany is an occurrence dataset published by the Research Institute of Nature and Forest (INBO). It is part of the LIFE project MICA, in which innovative techniques are tested for a more efficient control of muskrat and coypu populations, both invasive species. This dataset is a sample of the original dataset and serves as an example of a Camera Trap Data Package (Camtrap DP).",
   "version": "1.0",
   "keywords": [
     "camera traps",

--- a/media-observations-table-schema.json
+++ b/media-observations-table-schema.json
@@ -1,4 +1,5 @@
 {
+  "name": "media-observations",
   "title": "Media observations",
   "description": "Table with observations that are classified at media file level. Associated with media files via `mediaID`. Observations can mark non-animal events (camera setup, human, blank) or one or more animal observations (`observationType` = `animal`) of a certain taxon, count, life stage, sex, behavior and/or individual. Media observations are not required to be mutually exclusive, i.e. multiple classifications (e.g. human vs machine) of the same observed individual(s) are allowed.",
   "fields": [

--- a/media-table-schema.json
+++ b/media-table-schema.json
@@ -1,4 +1,5 @@
 {
+  "name": "media",
   "title": "Media",
   "description": "Table with media files (images/videos) captured by the camera traps. Associated with deployments (`deploymentID`) and organized in events (`eventID`). Includes timestamp and file path.",
   "fields": [


### PR DESCRIPTION
I removed the `name` property from the table schemas because it was no longer used by the validation and could be confused with the identical names of the resources using the schemas.

The IPT makes uses of that `name` property however and removing it caused issues (https://github.com/gbif/ipt/issues/1952#issuecomment-1444138714), so it's better to include it.

Note: it is fine that it is missing from version 0.6, since the schemas are copied for the IPT (and the `name` property was reintroduced manually in https://github.com/gbif/rs.gbif.org/commit/e3ef461b5d9ee8ccef681aebb8dd3c9d2b148c32).

Ping @mike-podolskiy90