### PR TITLE
Only allow empty string for missing values

### DIFF
--- a/deployments-table-schema.json
+++ b/deployments-table-schema.json
@@ -260,9 +260,7 @@
     }
   ],
   "missingValues": [
-    "",
-    "NaN",
-    "nan"
+    ""
   ],
   "primaryKey": "deploymentID"
 }

--- a/event-observations-table-schema.json
+++ b/event-observations-table-schema.json
@@ -212,9 +212,7 @@
     }
   ],
   "missingValues": [
-    "",
-    "NaN",
-    "nan"
+    ""
   ],
   "primaryKey": "observationID",
   "foreignKeys": [

--- a/media-observations-table-schema.json
+++ b/media-observations-table-schema.json
@@ -224,9 +224,7 @@
     }
   ],
   "missingValues": [
-    "",
-    "NaN",
-    "nan"
+    ""
   ],
   "primaryKey": "observationID",
   "foreignKeys": [

--- a/media-table-schema.json
+++ b/media-table-schema.json
@@ -127,9 +127,7 @@
     }
   ],
   "missingValues": [
-    "",
-    "NaN",
-    "nan"
+    ""
   ],
   "primaryKey": "mediaID",
   "foreignKeys": [


### PR DESCRIPTION
I think it is fine to have it as a requirement that missing values MUST be expressed as empty strings in the CSVs. So not allowing `NaN`, `nan` or `NA`. CSV writers are very likely to meet that requirement.