### PR TITLE
Update fileMediaType (and filePublic)

### DIFF
--- a/media-table-schema.json
+++ b/media-table-schema.json
@@ -63,6 +63,7 @@
     {
       "name": "filePublic",
       "description": "`false` if the media file is not publicly accessible (e.g. to protect the privacy of people).",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/serviceExpectation",
       "type": "boolean",
       "constraints": {
         "required": true

--- a/media-table-schema.json
+++ b/media-table-schema.json
@@ -80,11 +80,12 @@
     },
     {
       "name": "fileMediatype",
-      "description": "Mediatype of the media file.",
+      "description": "Mediatype of the media file. Expressed as an [IANA Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml).",
       "skos:broadMatch": "http://purl.org/dc/elements/1.1/format",
       "type": "string",
       "constraints": {
-        "required": true
+        "required": true,
+        "pattern": "^(image|video|audio)\/.*$"
       },
       "example": "image/jpeg"
     },

--- a/media-table-schema.json
+++ b/media-table-schema.json
@@ -81,6 +81,7 @@
     {
       "name": "fileMediatype",
       "description": "Mediatype of the media file.",
+      "skos:broadMatch": "http://purl.org/dc/elements/1.1/format",
       "type": "string",
       "constraints": {
         "required": true


### PR DESCRIPTION
- Link fileMediaType to dc:format, closes #338. I used broadMatch, since dc:format can also describe physical media, while we only allow digital formats.
- Mention IANA in fileMediatype and add regular expression, closes #341.
- Link filePublic to ac:serviceExpectation, closes #339. I used broadMatch, since serviceExpectation allows physical media and does not impose a controlled value (or boolean). 