### PR TITLE
Typo fixes

### DIFF
--- a/tests/httpserver.py
+++ b/tests/httpserver.py
@@ -20,7 +20,7 @@ def ServeDirectoryWithHTTP(directory="."):
     The server serves files from the given *directory*. The port listening on
     will automatically be picked by the operating system to avoid race
     conditions when trying to bind to an open port that turns out not to be
-    free afterall. The hostname is always "localhost".
+    free after all. The hostname is always "localhost".
 
     Parameters
     ----------
@@ -33,7 +33,7 @@ def ServeDirectoryWithHTTP(directory="."):
         The HTTP server which is serving files from a separate thread.
 
         It is not super necessary but you might want to call shutdown() on the
-        returned HTTP server object. This will stop the inifinite request loop
+        returned HTTP server object. This will stop the infinite request loop
         running in the thread which in turn will then exit. The reason why this
         is only optional is that the thread in which the server runs is a daemon
         thread which will be terminated when the main thread ends.


### PR DESCRIPTION
Two minor typo fixes:

```
./tests/httpserver.py:23: afterall ==> after all
./tests/httpserver.py:36: inifinite ==> infinite
```