### PR TITLE
Prepare version 1.0.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: 'To cite "Camtrap DP" in publications use:'
 type: software
 license: MIT
 title: Camera Trap Data Package (Camtrap DP)
-version: 1.0
+version: 1.0.1
 authors:
   - given-names: Peter
     family-names: Desmet
@@ -18,5 +18,5 @@ authors:
   - name: Camtrap DP Development Team
 repository-code: https://github.com/tdwg/camtrap-dp
 url: https://camtrap-dp.tdwg.org/
-date-released: '2023-11-03'
+date-released: '2024-08-21'
 doi: 10.5281/zenodo.10068760

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -5,7 +5,7 @@
   "type": "object",
   "$defs": {
     "version": {
-      "pattern": "1\\.0"
+      "pattern": "1\\.0\\.1"
     }
   },
   "allOf": [

--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -10,7 +10,7 @@
   },
   "allOf": [
     {
-      "$ref": "https://frictionlessdata.io/schemas/data-package.json"
+      "$ref": "https://specs.frictionlessdata.io/schemas/data-package.json"
     },
     {
       "required": [

--- a/example/datapackage.json
+++ b/example/datapackage.json
@@ -7,7 +7,7 @@
       "format": "csv",
       "mediatype": "text/csv",
       "encoding": "utf-8",
-      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/deployments-table-schema.json"
+      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.1/deployments-table-schema.json"
     },
     {
       "name": "media",
@@ -16,7 +16,7 @@
       "format": "csv",
       "mediatype": "text/csv",
       "encoding": "utf-8",
-      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/media-table-schema.json"
+      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.1/media-table-schema.json"
     },
     {
       "name": "observations",
@@ -25,7 +25,7 @@
       "format": "csv",
       "mediatype": "text/csv",
       "encoding": "utf-8",
-      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/observations-table-schema.json"
+      "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.1/observations-table-schema.json"
     },
     {
       "name": "individuals",
@@ -39,7 +39,7 @@
       ]
     }
   ],
-  "profile": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/camtrap-dp-profile.json",
+  "profile": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.1/camtrap-dp-profile.json",
   "name": "camtrap-dp-example-dataset",
   "id": "7cca70f5-ef8c-4f86-85fb-8f070937d7ab",
   "created": "2023-02-06T11:23:03Z",
@@ -81,7 +81,7 @@
     }
   ],
   "description": "MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany is an occurrence dataset published by the Research Institute of Nature and Forest (INBO). It is part of the LIFE project MICA, in which innovative techniques are tested for a more efficient control of muskrat and coypu populations, both invasive species. This dataset is a sample of the original dataset and serves as an example of a Camera Trap Data Package (Camtrap DP).",
-  "version": "1.0",
+  "version": "1.0.1",
   "keywords": [
     "camera traps",
     "public awareness campaign",
@@ -114,7 +114,7 @@
       "scope": "media"
     }
   ],
-  "bibliographicCitation": "Desmet P, Neukermans A, Van der beeck D, Cartuyvels E (2022). Sample from: MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany. Version 1.0. Research Institute for Nature and Forest (INBO). Dataset. https://camtrap-dp.tdwg.org/example/",
+  "bibliographicCitation": "Desmet P, Neukermans A, Van der beeck D, Cartuyvels E (2022). Sample from: MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany. Version 1.0.1. Research Institute for Nature and Forest (INBO). Dataset. https://camtrap-dp.tdwg.org/example/",
   "project": {
     "id": "86cabc14-d475-4439-98a7-e7b590bed60e",
     "title": "Management of Invasive Coypu and muskrAt in Europe",

--- a/pages/example.md
+++ b/pages/example.md
@@ -14,8 +14,8 @@ The dataset is derived from a [camera trap study](https://lifemica.eu/research-i
 
 Camtrap DP version | Dataset download | Dataset on GitHub
 --- | --- | ---
-`1.0` | [Download](https://download-directory.github.io?url=https://github.com/tdwg/camtrap-dp/tree/1.0/example){:.btn .btn-sm .btn-primary target="_blank"} | [GitHub](https://github.com/tdwg/camtrap-dp/tree/1.0/example){:.btn .btn-sm .btn-outline-primary}
 `1.0.1` | [Download](https://download-directory.github.io?url=https://github.com/tdwg/camtrap-dp/tree/1.0.1/example){:.btn .btn-sm .btn-primary target="_blank"} | [GitHub](https://github.com/tdwg/camtrap-dp/tree/1.0.1/example){:.btn .btn-sm .btn-outline-primary}
+`1.0` | [Download](https://download-directory.github.io?url=https://github.com/tdwg/camtrap-dp/tree/1.0/example){:.btn .btn-sm .btn-primary target="_blank"} | [GitHub](https://github.com/tdwg/camtrap-dp/tree/1.0/example){:.btn .btn-sm .btn-outline-primary}
 
 ## Preview
 

--- a/pages/example.md
+++ b/pages/example.md
@@ -15,6 +15,7 @@ The dataset is derived from a [camera trap study](https://lifemica.eu/research-i
 Camtrap DP version | Dataset download | Dataset on GitHub
 --- | --- | ---
 `1.0` | [Download](https://download-directory.github.io?url=https://github.com/tdwg/camtrap-dp/tree/1.0/example){:.btn .btn-sm .btn-primary target="_blank"} | [GitHub](https://github.com/tdwg/camtrap-dp/tree/1.0/example){:.btn .btn-sm .btn-outline-primary}
+`1.0.1` | [Download](https://download-directory.github.io?url=https://github.com/tdwg/camtrap-dp/tree/1.0.1/example){:.btn .btn-sm .btn-primary target="_blank"} | [GitHub](https://github.com/tdwg/camtrap-dp/tree/1.0.1/example){:.btn .btn-sm .btn-outline-primary}
 
 ## Preview
 
@@ -42,4 +43,4 @@ The selected deployments covers a wide range of use cases:
 
 ## Citation
 
-> Desmet P, Neukermans A, Van der beeck D, Cartuyvels E (2022). Sample from: MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany. Version 1.0. Research Institute for Nature and Forest (INBO). Dataset. <https://camtrap-dp.tdwg.org/example/>
+> Desmet P, Neukermans A, Van der beeck D, Cartuyvels E (2022). Sample from: MICA - Muskrat and coypu camera trap observations in Belgium, the Netherlands and Germany. Version 1.0.1. Research Institute for Nature and Forest (INBO). Dataset. <https://camtrap-dp.tdwg.org/example/>


### PR DESCRIPTION
The [differences](https://github.com/tdwg/camtrap-dp/compare/1.0...main) between this version and 1.0 are:

- Fix issue preventing validation with frictionless-py 5.17 and up (#383).
- Remove BOM character from example `observations.csv` (#370).
- Remove superfluous `spatial.bbox` from example `datapackage.json` (#370).
- Update some links in definitions (#368).
- Update README, homepage and add CITATION.cff (#382).
- Fix typos in test documentation (#372).