### PR TITLE
Add keywords to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,3 +20,8 @@ repository-code: https://github.com/tdwg/camtrap-dp
 url: https://camtrap-dp.tdwg.org/
 date-released: '2024-08-21'
 doi: 10.5281/zenodo.10068760
+keywords:
+- camera trapping
+- data exchange format
+- standard
+- frictionlessdata


### PR DESCRIPTION
This allows to automatically set the keywords on Zenodo when a GitHub release triggers a deposit on Zenodo