### PR TITLE
Repeat that "resources" is required

### DIFF
--- a/camtrap-dp-profile.json
+++ b/camtrap-dp-profile.json
@@ -14,6 +14,7 @@
     },
     {
       "required": [
+        "resources",
         "profile",
         "created",
         "contributors",


### PR DESCRIPTION
It is defined in https://specs.frictionlessdata.io/schemas/data-package.json, but by repeating it, resources* gets an asterisk in https://camtrap-dp.tdwg.org/metadata/#resources, making it clear that it is required.