### PR TITLE
Refer to camtrapdp software (rather than camtraptor) in example dataset

### DIFF
--- a/example/datapackage.json
+++ b/example/datapackage.json
@@ -265,7 +265,7 @@
     },
     {
       "relationType": "IsSupplementTo",
-      "relatedIdentifier": "https://inbo.github.io/camtraptor/",
+      "relatedIdentifier": "https://inbo.github.io/camtrapdp/",
       "resourceTypeGeneral": "Software",
       "relatedIdentifierType": "URL"
     }


### PR DESCRIPTION
I think it makes more sense to refer to the camtrapdp R package than the more specialized camtraptor R package in the example dataset. The camtrapdp R package makes extensive use of this example dataset, and even has a function to load it: https://inbo.github.io/camtrapdp/reference/example_dataset.html 