### PR TITLE
Add a button at bottom of FAQ to ask question

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -120,3 +120,9 @@ We provide an [R package](https://inbo.github.io/camtrapdp/) to read and manipul
 
 Consult the merge function documentation to understand exactly how specific fields are merged to avoid information loss. Please note that when merging data packages x and y, the [`project$samplingDesign`](/metadata/#project.samplingDesign) field in the resulting package will be set to the value of `project$samplingDesign` from data package x. Therefore, we recommend merging data packages only for projects that use the same sampling design.
 
+{:id="ask"}
+## Have a question?
+
+Don't see your question answered here?
+
+[Ask it in our discussion forum](https://github.com/tdwg/camtrap-dp/discussions){:.btn .btn-primary}


### PR DESCRIPTION
This came up in a BIG_PICTURE meeting. We have a FAQ, but people might have more questions (that we could add). This PR adds a section at the bottom of the FAQ with a button to do so:

<img width="632" alt="Screenshot 2025-06-16 at 16 29 07" src="https://github.com/user-attachments/assets/2cf33313-e74a-458f-9047-38c097d3c643" />

I'm adding it at the bottom, so they read/navigate through the existing answers first.

Rather than it linking to GitHub issues, I think it's better to use our underused discussion forum: https://github.com/tdwg/camtrap-dp/discussions